### PR TITLE
Properly link to contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,24 +19,44 @@ time of public release, here's how the contributors list looked:
  * 0 releases
  * 19 contributors
 
-```
-kmatthias 97 commits / 3,870 ++ / 3,658 --
-nic       36 commits / 1,481 ++ / 971 --
-bryan     15 commits / 355 ++ / 236 --
-andrew    47 commits / 326 ++ / 55 --
-jdearing  31 commits / 300 ++ / 152 --
-jon       17 commits / 242 ++ / 26 --
-dkerr      7 commits / 212 ++ / 6 --
-aaron      2 commits / 111 ++ / 23 --
-bkayser    7 commits / 106 ++ / 74 --
-jlepper    7 commits / 96 ++ / 46 --
-didip      5 commits / 93 ++ / 18 --
-dcelis     4 commits / 66 ++ / 12 --
-jthurman   2 commits / 40 ++ / 6 --
-amjith     7 commits / 38 ++ / 22 --
-brett      1 commit  / 26 ++ / 0 --
-merlyn     2 commits / 15 ++ / 2 --
-jonathan   1 commit  / 13 ++ / 10 --
-ehyland    5 commits / 6 ++ / 2 --
-franky     1 commit  / 2 ++ / 0 --
-```
+Contributor                                   | Commits    | Additions | Deletions
+----------------------------------------------|------------|-----------|----------
+[Karl Matthias][relistan]                     | 97 commits | 3,870 ++  | 3,658 --
+[Nic Benders][benders]                        | 36 commits | 1,481 ++  | 971 --
+[Bryan Stearns][bryanstearns]                 | 15 commits | 355 ++    | 236 --
+[Andrew Bloomgarden][aughr]                   | 47 commits | 326 ++    | 55 --
+[Jesse Dearing][jessedearing]                 | 31 commits | 300 ++    | 152 --
+[Jon Guymon][gnarg]                           | 17 commits | 242 ++    | 26 --
+[David Kerr][kerr23]                          |  7 commits | 212 ++    | 6 --
+[Aaron Bento][rkive]                          |  2 commits | 111 ++    | 23 --
+[Bill Kayser][bkayser]                        |  7 commits | 106 ++    | 74 --
+[Joe Lepper][joeLepper]                       |  7 commits | 96 ++     | 46 --
+[Didip Kerabat][didip]                        |  5 commits | 93 ++     | 18 --
+[David Celis][davidcelis]                     |  4 commits | 66 ++     | 12 --
+[Jonathan Thurman][jthurman42]                |  2 commits | 40 ++     | 6 --
+[Amjith Ramanujam][amjith]                    |  7 commits | 38 ++     | 22 --
+[Brett Holt][holtbp]                          |  1 commit  | 26 ++     | 0 --
+[Merlyn Albery-Speyer][curious-attempt-bunny] |  2 commits | 15 ++     | 2 --
+[Jonathan Owens][intjonathan]                 |  1 commit  | 13 ++     | 10 --
+[Emily Hyland][duien]                         |  5 commits | 6 ++      | 2 --
+[Franky Wahl][frankywahl]                     |  1 commit  | 2 ++      | 0 --
+
+[relistan]: https://github.com/relistan
+[benders]: https://github.com/benders
+[bryanstearns]: https://github.com/bryanstearns
+[aughr]: https://github.com/aughr
+[jessedearing]: https://github.com/jessedearing
+[gnarg]: https://github.com/gnarg
+[kerr23]: https://github.com/kerr23
+[rkive]: https://github.com/rkive
+[bkayser]: https://github.com/bkayser
+[joeLepper]: https://github.com/joeLepper
+[didip]: https://github.com/didip
+[davidcelis]: https://github.com/davidcelis
+[jthurman42]: https://github.com/jthurman42
+[amjith]: https://github.com/amjith
+[holtbp]: https://github.com/holtbp
+[curious-attempt-bunny]: https://github.com/curious-attempt-bunny
+[intjonathan]: https://github.com/intjonathan
+[duien]: https://github.com/duien
+[frankywahl]: https://github.com/frankywahl


### PR DESCRIPTION
Additionally, attribute them via public GitHub name as opposed to first
initial and last name

Signed-off-by: David Celis me@davidcel.is
