### PR TITLE
Use `/` as the default status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Centurion
 =========
 
 A deployment tool for Docker. Takes containers from a Docker registry and runs
-them on a fleet of hosts with the correct environment variables, host volume 
+them on a fleet of hosts with the correct environment variables, host volume
 mappings, and port mappings. Supports rolling deployments out of the box, and
 makes it easy to ship applications to Docker servers.
 
@@ -35,7 +35,7 @@ Installation
 Centurion is a Ruby gem. It assumes that you have a working, modern-ish Ruby
 (1.9.3 or higher). On Ubuntu 12.04 you can install this with the `ruby-1.9.1`
 system package, for example. On OSX this is best accomplished via `rbenv` and
-`ruby-build` which can be installed with [Homebrew](http://brew.sh/) or from 
+`ruby-build` which can be installed with [Homebrew](http://brew.sh/) or from
 [GitHub](https://github.com/sstephenson/rbenv).
 
 Once you have a running, modern Ruby, you simply:
@@ -144,9 +144,11 @@ distributed containers easy.  Here are some examples:
 
 A rolling deployment will stop and start each container one at a time to make
 sure that the application stays available from the viewpoint of the load
-balancer.  Currently assumes a valid response in the 200 range on
-`/status/check` by default. This is configurable by adding
-`set(:status_endpoint, '/somewhere')` in your config.
+balancer. As the deploy runs, a health check will hit each container to ensure
+that the application booted correctly. By default, this will be a GET request to
+the root path of the application. This is configurable by adding
+`set(:status_endpoint, '/somewhere/else')` in your config. The status endpoint
+must respond with a valid response in the 200 status range.
 
 ````bash
 $ bundle exec centurion -p radio-radio -e staging -a rolling_deploy

--- a/bin/centurionize
+++ b/bin/centurionize
@@ -22,25 +22,27 @@ unless File.exists?(project_file)
     namespace :environment do
       task :common do
         set :image, '#{opts[:registry_base]}#{opts[:project]}'
+        # Point this to an appropriate health check endpoint for rolling deploys (defaults to '/')
+        # set :status_endpoint, '/status'
       end
-    
+
       desc 'Staging environment'
       task :staging => :common do
         set_current_environment(:staging)
-        #env_vars YOUR_ENV: 'staging'
-        #host_port 10234, container_port: 9292
-        #host 'docker-server-staging-1.example.com'
-        #host 'docker-server-staging-2.example.com'
+        # env_vars YOUR_ENV: 'staging'
+        # host_port 10234, container_port: 9292
+        # host 'docker-server-staging-1.example.com'
+        # host 'docker-server-staging-2.example.com'
       end
-    
+
       desc 'Production environment'
       task :production => :common do
         set_current_environment(:production)
-        #env_vars YOUR_ENV: 'production'
-        #host_port 23235, container_port: 9293
-        #host 'docker-server-prod-1.example.com'
-        #host 'docker-server-prod-2.example.com'
-        #host_volume '/mnt/volume1', container_volume: '/mnt/volume1'
+        # env_vars YOUR_ENV: 'production'
+        # host_port 23235, container_port: 9293
+        # host 'docker-server-prod-1.example.com'
+        # host 'docker-server-prod-2.example.com'
+        # host_volume '/mnt/volume1', container_volume: '/mnt/volume1'
       end
     end
   EOS

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -84,7 +84,7 @@ namespace :deploy do
         wait_for_http_status_ok(
           server,
           host_ports.first['HostPort'],
-          fetch(:status_endpoint, '/status/check'),
+          fetch(:status_endpoint, '/'),
           fetch(:image),
           fetch(:tag),
           fetch(:rolling_deploy_wait_time, 5),


### PR DESCRIPTION
It seems strange to have the default status endpoint set as
`/status/check`, as most people do not implement this as an endpoint in
their web applications. The `/status/check` endpoint is more of an
internal convention than a community standard, so we should default this
to something more likely to be able to report an application's health.
In most cases, the root path should simply work for this out of the box.

Signed-off-by: David Celis me@davidcel.is
