### PR TITLE
Fix (mostly) the DockerRegistry class which was not very useful.

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -63,6 +63,7 @@ set :hosts, opts[:hosts].split(",") if opts[:hosts]
 
 # Default tag should be "latest"
 set :tag, 'latest' unless any?(:tag)
+set :docker_registry, 'https://registry.hub.docker.com/'
 
 # Specify a path to docker executable
 set :docker_path, opts[:docker_path]

--- a/lib/centurion/docker_registry.rb
+++ b/lib/centurion/docker_registry.rb
@@ -5,12 +5,11 @@ require 'uri'
 module Centurion; end
 
 class Centurion::DockerRegistry
-  def initialize()
-    # @base_uri = "https://staging-docker-registry.nr-ops.net"
-    @base_uri = 'http://chi-docker-registry.nr-ops.net'
+  def initialize(base_uri)
+    @base_uri = base_uri
   end
   
-  def digest_for_tag( repository, tag)
+  def digest_for_tag(repository, tag)
     path = "/v1/repositories/#{repository}/tags/#{tag}"
     $stderr.puts "GET: #{path.inspect}"
     response = Excon.get(
@@ -25,8 +24,8 @@ class Centurion::DockerRegistry
     JSON.load('[' + response.body + ']').first
   end
   
-  def respository_tags( respository )
-    path = "/v1/repositories/#{respository}/tags"
+  def repository_tags(repository)
+    path = "/v1/repositories/#{repository}/tags"
     $stderr.puts "GET: #{path.inspect}"
     response = Excon.get(@base_uri + path)
     raise response.inspect unless response.status == 200

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -103,7 +103,7 @@ namespace :deploy do
   end
 
   task :determine_image_id do
-    registry = Centurion::DockerRegistry.new()
+    registry = Centurion::DockerRegistry.new(fetch(:docker_registry))
     exact_image = registry.digest_for_tag(fetch(:image), fetch(:tag))
     set :image_id, exact_image
     $stderr.puts "RESOLVED #{fetch(:image)}:#{fetch(:tag)} => #{exact_image[0..11]}"

--- a/lib/tasks/list.rake
+++ b/lib/tasks/list.rake
@@ -24,8 +24,8 @@ namespace :list do
 
   task :tags do
     begin
-      registry = Centurion::DockerRegistry.new()
-      tags = registry.respository_tags(fetch(:image))
+      registry = Centurion::DockerRegistry.new(fetch(:docker_registry))
+      tags = registry.repository_tags(fetch(:image))
       tags.each do |tag|
         puts "\t#{tag[0]}\t-> #{tag[1][0..11]}"
       end


### PR DESCRIPTION
The `DockerRegistry` class was not generally very useful the way it was set up. There are still shortcomings in this fix as it doesn't support registry auth, but it is more generally useful.  It now points to the main public Docker repository at the Docker Hub.

Sadly, this class is lacking in tests and needs a full suite!

@jessedearing @bryannewrelic review appreciated.
