### PR TITLE
Use local images

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -34,6 +34,7 @@ opts = Trollop::options do
   opt :tag,         'tag (latest...)',                             type: String, required: false, short: '-t'
   opt :hosts,       'hosts, comma separated',                      type: String, required: false, short: '-h'
   opt :docker_path, 'path to docker executable (default: docker)', type: String, default: 'docker', short: '-d'
+  opt :no_pull,     'Skip the pull_image step',                    type: :flag, default: false, long: '--no-pull'
 end
 
 unless possible_environments.include?(opts[:environment])
@@ -67,5 +68,7 @@ set :docker_registry, 'https://registry.hub.docker.com/'
 
 # Specify a path to docker executable
 set :docker_path, opts[:docker_path]
+
+set :no_pull, opts[:no_pull]
 
 invoke(opts[:action])

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -120,6 +120,10 @@ namespace :deploy do
   end
 
   task :pull_image do
+    if fetch(:no_pull)
+      info "--no-pull option specified: skipping pull"
+      next
+    end
     $stderr.puts "Fetching image #{fetch(:image)}:#{fetch(:tag)} IN PARALLEL\n"
 
     target_servers = Centurion::DockerServerGroup.new(fetch(:hosts), fetch(:docker_path))


### PR DESCRIPTION
If the user has not specified a registry in their image then assume it's a locally tagged image.

This is useful in testing before you push to a registry
