### PR TITLE
Use official IANA docker port, now that there is one

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -23,7 +23,7 @@ module Centurion::DeployDSL
   end
 
   def localhost
-    # DOCKER_HOST is like 'tcp://127.0.0.1:4243'
+    # DOCKER_HOST is like 'tcp://127.0.0.1:2375'
     docker_host_uri = URI.parse(ENV['DOCKER_HOST'] || "tcp://127.0.0.1")
     host_and_port = [docker_host_uri.host, docker_host_uri.port].compact.join(':')
     host(host_and_port)

--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -21,7 +21,7 @@ class Centurion::DockerServer
   def initialize(host, docker_path)
     @docker_path = docker_path
     @hostname, @port = host.split(':')
-    @port ||= '4243'
+    @port ||= '2375'
   end
 
   def current_tags_for(image)

--- a/spec/docker_server_spec.rb
+++ b/spec/docker_server_spec.rb
@@ -11,7 +11,7 @@ describe Centurion::DockerServer do
   end
 
   it 'knows its port' do
-    expect(server.port).to eq('4243')
+    expect(server.port).to eq('2375')
   end
 
   describe 'when host includes a port' do

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -3,7 +3,7 @@ require 'centurion/docker_via_api'
 
 describe Centurion::DockerViaApi do
   let(:hostname) { 'example.com' }
-  let(:port) { '4243' }
+  let(:port) { '2375' }
   let(:api) { Centurion::DockerViaApi.new(hostname, port) }
   let(:excon_uri) { "http://#{hostname}:#{port}/" }
   let(:json_string) { '[{ "Hello": "World" }]' }

--- a/spec/docker_via_cli_spec.rb
+++ b/spec/docker_via_cli_spec.rb
@@ -3,24 +3,24 @@ require 'centurion/docker_via_cli'
 
 describe Centurion::DockerViaCli do
   let(:docker_path) { 'docker' }
-  let(:docker_via_cli) { Centurion::DockerViaCli.new('host1', 4243, docker_path) }
+  let(:docker_via_cli) { Centurion::DockerViaCli.new('host1', 2375, docker_path) }
 
   it 'pulls the latest image given its name' do
     expect(docker_via_cli).to receive(:echo).
-                              with("docker -H=tcp://host1:4243 pull foo:latest")
+                              with("docker -H=tcp://host1:2375 pull foo:latest")
     docker_via_cli.pull('foo')
   end
 
   it 'pulls an image given its name & tag' do
     expect(docker_via_cli).to receive(:echo).
-                              with("docker -H=tcp://host1:4243 pull foo:bar")
+                              with("docker -H=tcp://host1:2375 pull foo:bar")
     docker_via_cli.pull('foo', 'bar')
   end
 
   it 'tails logs on a container' do
     id = '12345abcdef'
     expect(docker_via_cli).to receive(:echo).
-                              with("docker -H=tcp://host1:4243 logs -f #{id}")
+                              with("docker -H=tcp://host1:2375 logs -f #{id}")
     docker_via_cli.tail(id)
   end
 


### PR DESCRIPTION
We should default to the official IANA port for docker, now that it exists. The old port conflicts with Crashplan (and possibly others)
