### PR TITLE
Better information about failed sub-processes

### DIFF
--- a/lib/centurion/docker_via_cli.rb
+++ b/lib/centurion/docker_via_cli.rb
@@ -52,10 +52,7 @@ class Centurion::DockerViaCli
     end
 
     output_thread.kill
-
-    unless $?.success?
-      raise "The command failed with a non-zero exit status: #{$?.exitstatus}"
-    end
+    validate_status(command)
   end
 
   def run_with_echo( command )
@@ -64,8 +61,12 @@ class Centurion::DockerViaCli
     IO.popen(command) do |io|
       io.each_char { |char| print char }
     end
+    validate_status(command)
+  end
+
+  def validate_status(command)
     unless $?.success?
-      raise "The command failed with a non-zero exit status: #{$?.exitstatus}"
+      raise "The command failed with a non-zero exit status: #{$?.exitstatus}. Command: '#{command}'"
     end
   end
 end


### PR DESCRIPTION
This PR should make it easier to understand what went wrong with the Docker CLI when it's running under Centurion by printing out the command that was run as well as the error. Also reduces code duplication.
