### PR TITLE
Vagrant File to start a fleet of docker servers

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,6 @@ require 'fileutils'
 
 # Defaults for config options defined in CONFIG
 $num_instances = 3
-$user_data_config_file = "./user-data"
-
 
 # Vagrantfile API/syntax version.
 VAGRANTFILE_API_VERSION = "2"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,8 +19,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  #config.vm.box = "precise64"
   config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "vmware_fusion" do |v, override|
+    override.vm.box = "hvolpers/trusty64"
+  end
 
   (1..$num_instances).each do |i|
     config.vm.define vm_name = "docker-fleet-%02d" % i do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,54 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+#
+# Docker-fleet - Spins up a fleet of docker enabled machines on Ubuntu 14.04
+#
+
+require 'fileutils'
+
+# Defaults for config options defined in CONFIG
+$num_instances = 3
+$user_data_config_file = "./user-data"
+
+
+# Vagrantfile API/syntax version.
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  #config.vm.box = "precise64"
+  config.vm.box = "ubuntu/trusty64"
+
+  (1..$num_instances).each do |i|
+    config.vm.define vm_name = "docker-fleet-%02d" % i do |config|
+
+      config.vm.hostname = vm_name
+      config.vm.network "private_network", type: "dhcp"
+
+      # Provider-specific configuration so you can fine-tune various
+      # backing providers for Vagrant. These expose provider-specific options.
+      # Example for VirtualBox:
+      #
+      config.vm.provider :virtualbox do |vb|
+        #   # Don't boot with headless mode
+        #   vb.gui = true
+        #
+        #   # Use VBoxManage to customize the VM. For example to change memory:
+        vb.customize ["modifyvm", :id, "--memory", "1024"]
+      end
+
+      if File.exist?("./vagrant/user-data")
+        config.vm.provision "shell", path: "./vagrant/user-data"
+      end
+
+    end
+  end
+
+
+
+end

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -3,6 +3,19 @@ Vagrant Usage
 
 The vagrant setup deploys a fleet of Docker servers ready for Centurion to deploy into.
 
+## Requirements
+
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads) 4.2+
+* [Vagrant](https://www.vagrantup.com/downloads.html) 1.6+
+
+## Quick Start
+
+1. [Install VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+
+1. [Install Vagrant](http://www.vagrantup.com/downloads.html)
+
+1. Clone this repository
+
 Usage
 ---------
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -21,5 +21,3 @@ It will do a bunch of stuff and after the command prompt returns to you you can 
     vagrant status
 
 At this point you can follow the instructions on how to use Centurion against this fleet of Docker server.
-
-

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,25 @@
+Vagrant Usage
+=========
+
+The vagrant setup deploys a fleet of Docker servers ready for Centurion to deploy into.
+
+Usage
+---------
+
+By default, it is setup to create 3 Docker server instances.  It is installing the latest Docker version onto Ubuntu Trusty (14.04).  You can change that value in the "Vagrantfile" at the root of this project
+
+     $num_instances = 3
+
+# Starting Vagrant instances
+
+At the root of this project start up the Vagrant instances
+
+    vagrant up
+
+It will do a bunch of stuff and after the command prompt returns to you you can view the instances with this command:
+
+    vagrant status
+
+At this point you can follow the instructions on how to use Centurion against this fleet of Docker server.
+
+

--- a/vagrant/user-data
+++ b/vagrant/user-data
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Get latest Docker.io version
+# Docs: https://docs.docker.com/installation/ubuntulinux/#ubuntu-trusty-1404-lts-64-bit
+curl -s https://get.docker.io/ubuntu/ | sudo sh
+
+# Enable docker to respond on socket and tcp
+echo 'DOCKER_OPTS="-H=0.0.0.0:2375 -H unix:///var/run/docker.sock"' >> /etc/default/docker
+service docker restart
+
+# install ruby bundle
+gem install bundle
+
+# Download centurion
+cd /home/vagrant
+git clone https://github.com/newrelic/centurion.git
+
+# install gems for centurion
+cd centurion
+bundle install
+
+# Create test project and centurion scaffolding
+#cd ..
+#mkdir my_test
+#cd my_test
+#exec ../centurion/bin/centurionize -p my_test
+     # at the end of this...it exits the command shell for some reason.  Have to look at what it is doing
+
+

--- a/vagrant/user-data
+++ b/vagrant/user-data
@@ -7,23 +7,3 @@ curl -s https://get.docker.io/ubuntu/ | sudo sh
 # Enable docker to respond on socket and tcp
 echo 'DOCKER_OPTS="-H=0.0.0.0:2375 -H unix:///var/run/docker.sock"' >> /etc/default/docker
 service docker restart
-
-# install ruby bundle
-gem install bundle
-
-# Download centurion
-cd /home/vagrant
-git clone https://github.com/newrelic/centurion.git
-
-# install gems for centurion
-cd centurion
-bundle install
-
-# Create test project and centurion scaffolding
-#cd ..
-#mkdir my_test
-#cd my_test
-#exec ../centurion/bin/centurionize -p my_test
-     # at the end of this...it exits the command shell for some reason.  Have to look at what it is doing
-
-


### PR DESCRIPTION
Added a Vagrant files i used to start up a fleet of docker servers for local testing.  This makes it very easy to start a bunch of docker servers to point centurion against for testing.

There is also instructions on how to use this in the ./vagrant folder.