### PR TITLE
allow interpolation of docker hostname into env_vars

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -101,7 +101,9 @@ module Centurion::Deploy
     end
 
     if env_vars
-      container_config['Env'] = env_vars.map { |k,v| "#{k}=#{v}" }
+      container_config['Env'] = env_vars.map do |k,v|
+        "#{k}=#{v.gsub('$DOCKER_HOSTNAME', target_server.hostname)}"
+      end
     end
 
     if volumes

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -159,6 +159,12 @@ describe Centurion::Deploy do
       expect(config.keys).to match_array(%w{ Hostname Image })
     end
 
+    it 'interpolates the hostname into env_vars' do
+      config = test_deploy.container_config_for(server, 'image_id', {}, 'FOO' => '$DOCKER_HOSTNAME')
+
+      expect(config['Env']).to eq(['FOO=host1'])
+    end
+
     it 'handles mapping host volumes' do
       config = test_deploy.container_config_for(server, 'image_id', nil, nil, ["/tmp/foo:/tmp/chaucer"])
 


### PR DESCRIPTION
This would allow something like `env_vars SERVICE_HOST: 'http://$DOCKER_HOSTNAME:8888'` for services that are hosted on the docker host of the container.

@didip @intjonathan @spkane for review
