### PR TITLE
New feature: Able to pass specific Docker HTTP version. The DSL is: docker_http_version

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 module Centurion::DeployDSL
   def on_each_docker_host(&block)
-    Centurion::DockerServerGroup.new(fetch(:hosts, []), fetch(:docker_path)).tap do |hosts|
+    Centurion::DockerServerGroup.new(fetch(:hosts, []), fetch(:docker_path), fetch(:docker_http_version)).tap do |hosts|
       hosts.each { |host| block.call(host) }
     end
   end
@@ -34,7 +34,7 @@ module Centurion::DeployDSL
     require_options_keys(options,  [ :container_port ])
 
     add_to_bindings(
-      options[:host_ip] || '0.0.0.0', 
+      options[:host_ip] || '0.0.0.0',
       options[:container_port],
       port,
       options[:type] || 'tcp'
@@ -59,7 +59,7 @@ module Centurion::DeployDSL
   end
 
   def get_current_tags_for(image)
-    hosts = Centurion::DockerServerGroup.new(fetch(:hosts), fetch(:docker_path))
+    hosts = Centurion::DockerServerGroup.new(fetch(:hosts), fetch(:docker_path), fetch(:docker_http_version))
     hosts.inject([]) do |memo, target_server|
       tags = target_server.current_tags_for(image)
       memo += [{ server: target_server.hostname, tags: tags }] if tags

--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -18,10 +18,11 @@ class Centurion::DockerServer
                  :old_containers_for_port, :remove_container
   def_delegators :docker_via_cli, :pull, :tail, :attach
 
-  def initialize(host, docker_path)
+  def initialize(host, docker_path, docker_http_version="v1.13")
     @docker_path = docker_path
     @hostname, @port = host.split(':')
     @port ||= '4243'
+    @docker_http_version = docker_http_version
   end
 
   def current_tags_for(image)
@@ -44,7 +45,7 @@ class Centurion::DockerServer
   private
 
   def docker_via_api
-    @docker_via_api ||= Centurion::DockerViaApi.new(@hostname, @port)
+    @docker_via_api ||= Centurion::DockerViaApi.new(@hostname, @port, @docker_http_version)
   end
 
   def docker_via_cli

--- a/lib/centurion/docker_server_group.rb
+++ b/lib/centurion/docker_server_group.rb
@@ -8,10 +8,10 @@ class Centurion::DockerServerGroup
   include Centurion::Logging
 
   attr_reader :hosts
-  
-  def initialize(hosts, docker_path)
+
+  def initialize(hosts, docker_path, docker_http_version="v1.13")
     raise ArgumentError.new('Bad Host list!') if hosts.nil? || hosts.empty?
-    @hosts = hosts.map { |hostname| Centurion::DockerServer.new(hostname, docker_path) }
+    @hosts = hosts.map { |hostname| Centurion::DockerServer.new(hostname, docker_path, docker_http_version) }
   end
 
   def each(&block)

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -5,14 +5,14 @@ require 'uri'
 module Centurion; end
 
 class Centurion::DockerViaApi
-  def initialize(hostname, port)
-    @base_uri = "http://#{hostname}:#{port}"
+  def initialize(hostname, port, version="v1.13")
+    @base_uri = "http://#{hostname}:#{port}/#{version}"
 
     configure_excon_globally
   end
 
   def ps(options={})
-    path = "/v1.7/containers/json"
+    path = "/containers/json"
     path += "?all=1" if options[:all]
     response = Excon.get(@base_uri + path)
 
@@ -22,7 +22,7 @@ class Centurion::DockerViaApi
 
   def inspect_image(image, tag = "latest")
     repository = "#{image}:#{tag}"
-    path       = "/v1.7/images/#{repository}/json"
+    path       = "/images/#{repository}/json"
 
     response = Excon.get(
       @base_uri + path,
@@ -43,7 +43,7 @@ class Centurion::DockerViaApi
   end
 
   def remove_container(container_id)
-    path = "/v1.7/containers/#{container_id}"
+    path = "/containers/#{container_id}"
     response = Excon.delete(
       @base_uri + path,
     )
@@ -52,7 +52,7 @@ class Centurion::DockerViaApi
   end
 
   def stop_container(container_id)
-    path = "/v1.7/containers/#{container_id}/stop?t=30"
+    path = "/containers/#{container_id}/stop?t=30"
     response = Excon.post(
       @base_uri + path,
     )
@@ -61,7 +61,7 @@ class Centurion::DockerViaApi
   end
 
   def create_container(configuration)
-    path = "/v1.10/containers/create"
+    path = "/containers/create"
     response = Excon.post(
       @base_uri + path,
       :body => configuration.to_json,
@@ -72,7 +72,7 @@ class Centurion::DockerViaApi
   end
 
   def start_container(container_id, configuration)
-    path = "/v1.10/containers/#{container_id}/start"
+    path = "/containers/#{container_id}/start"
     response = Excon.post(
       @base_uri + path,
       :body => configuration.to_json,
@@ -89,7 +89,7 @@ class Centurion::DockerViaApi
   end
 
   def inspect_container(container_id)
-    path = "/v1.7/containers/#{container_id}/json"
+    path = "/containers/#{container_id}/json"
     response = Excon.get(
       @base_uri + path,
     )

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -126,7 +126,7 @@ namespace :deploy do
     end
     $stderr.puts "Fetching image #{fetch(:image)}:#{fetch(:tag)} IN PARALLEL\n"
 
-    target_servers = Centurion::DockerServerGroup.new(fetch(:hosts), fetch(:docker_path))
+    target_servers = Centurion::DockerServerGroup.new(fetch(:hosts), fetch(:docker_path), fetch(:docker_http_version))
     target_servers.each_in_parallel do |target_server|
       target_server.pull(fetch(:image), fetch(:tag))
     end

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -5,7 +5,8 @@ describe Centurion::DockerViaApi do
   let(:hostname) { 'example.com' }
   let(:port) { '4243' }
   let(:api) { Centurion::DockerViaApi.new(hostname, port) }
-  let(:excon_uri) { "http://#{hostname}:#{port}/" }
+  let(:version) { 'v1.13' }
+  let(:excon_uri) { "http://#{hostname}:#{port}/#{version}" }
   let(:json_string) { '[{ "Hello": "World" }]' }
   let(:json_value) { JSON.load(json_string) }
   let(:inspected_containers) do
@@ -18,21 +19,21 @@ describe Centurion::DockerViaApi do
 
   it 'lists processes' do
     expect(Excon).to receive(:get).
-                     with(excon_uri + "v1.7" + "/containers/json").
+                     with(excon_uri + "/containers/json").
                      and_return(double(body: json_string, status: 200))
     expect(api.ps).to eq(json_value)
   end
 
   it 'lists all processes' do
     expect(Excon).to receive(:get).
-                     with(excon_uri + "v1.7" + "/containers/json?all=1").
+                     with(excon_uri + "/containers/json?all=1").
                      and_return(double(body: json_string, status: 200))
     expect(api.ps(all: true)).to eq(json_value)
   end
 
   it 'inspects an image' do
     expect(Excon).to receive(:get).
-                     with(excon_uri + "v1.7" + "/images/foo:bar/json",
+                     with(excon_uri + "/images/foo:bar/json",
                           headers: {'Accept' => 'application/json'}).
                      and_return(double(body: json_string, status: 200))
     expect(api.inspect_image('foo', 'bar')).to eq(json_value)
@@ -42,7 +43,7 @@ describe Centurion::DockerViaApi do
     configuration_as_json = double
     configuration = double(:to_json => configuration_as_json)
     expect(Excon).to receive(:post).
-                         with(excon_uri + "v1.10" + "/containers/create",
+                         with(excon_uri + "/containers/create",
                               body: configuration_as_json,
                               headers: {'Content-Type' => 'application/json'}).
                          and_return(double(body: json_string, status: 201))
@@ -53,7 +54,7 @@ describe Centurion::DockerViaApi do
     configuration_as_json = double
     configuration = double(:to_json => configuration_as_json)
     expect(Excon).to receive(:post).
-                         with(excon_uri + "v1.10" + "/containers/12345/start",
+                         with(excon_uri + "/containers/12345/start",
                               body: configuration_as_json,
                               headers: {'Content-Type' => 'application/json'}).
                          and_return(double(body: json_string, status: 204))
@@ -62,34 +63,34 @@ describe Centurion::DockerViaApi do
 
   it 'stops a container' do
     expect(Excon).to receive(:post).
-                     with(excon_uri + "v1.7" + "/containers/12345/stop?t=30").
+                     with(excon_uri + "/containers/12345/stop?t=30").
                      and_return(double(status: 204))
     api.stop_container('12345')
   end
 
   it 'inspects a container' do
     expect(Excon).to receive(:get).
-                         with(excon_uri + "v1.7" + "/containers/12345/json").
+                         with(excon_uri + "/containers/12345/json").
                          and_return(double(body: json_string, status: 200))
     expect(api.inspect_container('12345')).to eq(json_value)
   end
 
   it 'removes a container' do
     expect(Excon).to receive(:delete).
-                         with(excon_uri + "v1.7" + "/containers/12345").
+                         with(excon_uri + "/containers/12345").
                          and_return(double(status: 204))
     expect(api.remove_container('12345')).to eq(true)
   end
 
   it 'lists old containers for a port' do
     expect(Excon).to receive(:get).
-                         with(excon_uri + "v1.7" + "/containers/json?all=1").
+                         with(excon_uri + "/containers/json?all=1").
                          and_return(double(body: inspected_containers.to_json, status: 200))
     expect(Excon).to receive(:get).
-                         with(excon_uri + "v1.7" + "/containers/123/json").
+                         with(excon_uri + "/containers/123/json").
                          and_return(double(body: inspected_container_on_port("123", 8485).to_json, status: 200))
     expect(Excon).to receive(:get).
-                         with(excon_uri + "v1.7" + "/containers/789/json").
+                         with(excon_uri + "/containers/789/json").
                          and_return(double(body: inspected_container_on_port("789", 8486).to_json, status: 200))
 
     expect(api.old_containers_for_port(8485)).to eq([{"Id" => "123", "Status" => "Exit 0"}])


### PR DESCRIPTION
Previously we have hardcoded API version numbers as part of the URL path.

This commit cleans all that up and the version defaults to `v1.13` (the latest version) if `docker_http_version` is not specified.
