### PR TITLE
Peg version of rspec in gemspec

### DIFF
--- a/centurion.gemspec
+++ b/centurion.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     runs them on a fleet of hosts with the correct environment variables, host
     mappings, and port mappings. Supports rolling deployments out of the box, and
     makes it easy to ship applications to Docker servers.
-    
+
     We're using it to run our production infrastructure.
   EOS
   spec.homepage      = 'https://github.com/newrelic/centurion'
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 2.14.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'simplecov'
 


### PR DESCRIPTION
The test suite fails under rspec 3. To prevent others from running into this problem, we can pessimistically peg the version to the 2.14.x line. Note that the test suite passes on 2.99.x, but gives a ton of deprecation warnings.

I know it's generally not best practice to specify dependencies in gemspecs because users may have unforeseen combinations of gems installed, but this seems pretty reasonable since it makes beginning development on the centurion gem a bit less mystifying.
