### PR TITLE
Handle Docker registry API inconsistency

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -64,7 +64,7 @@ set :hosts, opts[:hosts].split(",") if opts[:hosts]
 
 # Default tag should be "latest"
 set :tag, 'latest' unless any?(:tag)
-set :docker_registry, 'https://registry.hub.docker.com/'
+set :docker_registry, Centurion::DockerRegistry::OFFICIAL_URL
 
 # Specify a path to docker executable
 set :docker_path, opts[:docker_path]

--- a/spec/docker_registry_spec.rb
+++ b/spec/docker_registry_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'centurion/docker_registry'
+
+describe Centurion::DockerRegistry do
+  let(:registry_url) { 'http://localhost/' }
+  let(:registry) { Centurion::DockerRegistry.new(registry_url) }
+
+  describe '#repository_tags' do
+    let(:repository) { 'foobar' }
+    let(:tag_name) { 'arbitrary_tag' }
+    let(:image_id) { 'deadbeef0000' }
+
+    before do
+      expect(Excon).to receive(:get).
+                       and_return(double(status: 200, body: response))
+    end
+
+    subject { registry.repository_tags(repository) }
+
+    context 'when given a response from the official Docker registry' do
+      let(:registry_url) { Centurion::DockerRegistry::OFFICIAL_URL }
+      let(:response) { <<-JSON.strip }
+        [{"layer": "#{image_id}", "name": "#{tag_name}"}]
+      JSON
+
+      it 'normalizes the response' do
+        expect(subject).to eq(tag_name => image_id)
+      end
+    end
+
+    context 'when given a response from the open-source Docker registry' do
+      let(:response) { <<-JSON.strip }
+        {"#{tag_name}": "#{image_id}"}
+      JSON
+
+      it 'normalizes the response' do
+        expect(subject).to eq(tag_name => image_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I just opened [an issue here](https://github.com/docker/docker-registry/issues/517), but since this is a bug biting people now, I figure it's worth a fix here too.

The symptom is an error message like this:

``` bash
» bundle exec centurion -p [project] -e [env] -a list
** Invoke environment:staging (first_time)
** Invoke environment:common (first_time)
** Execute environment:common
** Execute environment:staging
** Invoke list (first_time)
** Execute list
** Invoke list:tags (first_time)
** Execute list:tags
GET: https://registry.hub.docker.com//v1/repositories/centos/tags
E, [2014-08-09T15:59:45.695148 #18183] ERROR -- : Couldn't communicate with Registry: undefined method `[]' for nil:NilClass
```

This is caused because if the user is using the official Docker registry to host their images, the API response for /v1/repositories/:repo/tags is quite different than the current [open-source registry](https://github.com/docker/docker-registry)'s response.

This commit / PR adds a standardization based on the URL of the registry. It's not perfect, but it seems likely to work for most folks.
