### PR TITLE
Added ability to specify arbitary Docker parameters

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -87,7 +87,7 @@ module Centurion::Deploy
     end
   end
 
-  def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil)
+  def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil, parameters=nil)
     container_config = {
       'Image'        => image_id,
       'Hostname'     => target_server.hostname,
@@ -112,11 +112,15 @@ module Centurion::Deploy
       container_config['VolumesFrom'] = 'parent'
     end
 
+    if parameters
+      container_config.merge!(parameters)
+    end
+
     container_config
   end
 
-  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil)
-    container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes)
+  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil, parameters=nil)
+    container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, parameters)
     start_container_with_config(target_server, volumes, port_bindings, container_config)
   end
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -51,7 +51,8 @@ namespace :deploy do
         fetch(:image_id),
         fetch(:port_bindings),
         fetch(:binds),
-        fetch(:env_vars)
+        fetch(:env_vars),
+        fetch(:parameters)
       )
     end
   end
@@ -77,7 +78,8 @@ namespace :deploy do
         fetch(:image_id),
         fetch(:port_bindings),
         fetch(:binds),
-        fetch(:env_vars)
+        fetch(:env_vars),
+        fetch(:parameters)
       )
 
       fetch(:port_bindings).each_pair do |container_port, host_ports|


### PR DESCRIPTION
I have a number of containers that require Tty and Stdin to be set (equivalent of launching with docker run and the "-t" and "-i" flags). I added a 'parameters' option, so you can now send arbitary flags to the Docker API, e.g.

namespace :environment do
  task :common do
    ...
    set :status_endpoint, '/'
    set :parameters, { 'Tty' => true, 'OpenStdin' => true  }
  end

This was based off the v1.0.10 tag.
