### PR TITLE
Remove static hostname for container

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -89,8 +89,7 @@ module Centurion::Deploy
 
   def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil, command=nil)
     container_config = {
-      'Image'        => image_id,
-      'Hostname'     => target_server.hostname,
+      'Image'        => image_id
     }
 
     container_config.merge!('Cmd' => command) if command


### PR DESCRIPTION
Allow support for dynamic hostnames (ephemeral containers). This will allow containers on the same host to communicate with each other.
@relistan @bkayser @rkbodenner @rkive @didip 
