### PR TITLE
Allow `set(:stop_timeout, <int>)` in configuration.

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -5,14 +5,14 @@ module Centurion; end
 module Centurion::Deploy
   FAILED_CONTAINER_VALIDATION = 100
 
-  def stop_containers(target_server, port_bindings)
+  def stop_containers(target_server, port_bindings, timeout = 30)
     public_port    = public_port_for(port_bindings)
     old_containers = target_server.find_containers_by_public_port(public_port)
     info "Stopping container(s): #{old_containers.inspect}"
 
     old_containers.each do |old_container|
       info "Stopping old container #{old_container['Id'][0..7]} (#{old_container['Names'].join(',')})"
-      target_server.stop_container(old_container['Id'])
+      target_server.stop_container(old_container['Id'], timeout)
     end
   end
 

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -51,8 +51,8 @@ class Centurion::DockerViaApi
     true
   end
 
-  def stop_container(container_id)
-    path = "/v1.7/containers/#{container_id}/stop?t=30"
+  def stop_container(container_id, timeout = 30)
+    path = "/v1.7/containers/#{container_id}/stop?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
     )

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -37,7 +37,9 @@ namespace :deploy do
   # - remote: list
   # - remote: stop
   task :stop do
-    on_each_docker_host { |server| stop_containers(server, fetch(:port_bindings)) }
+    on_each_docker_host do |server|
+      stop_containers(server, fetch(:port_bindings), fetch(:stop_timeout, 30))
+    end
   end
 
   # start
@@ -72,7 +74,7 @@ namespace :deploy do
 
   task :rolling_deploy do
     on_each_docker_host do |server|
-      stop_containers(server, fetch(:port_bindings))
+      stop_containers(server, fetch(:port_bindings), fetch(:stop_timeout, 30))
 
       start_new_container(
         server,

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -126,8 +126,8 @@ describe Centurion::Deploy do
 
       expect(server).to receive(:find_containers_by_public_port).and_return(containers)
       expect(test_deploy).to receive(:public_port_for).with(bindings).and_return('80')
-      expect(server).to receive(:stop_container).with(container['Id']).once
-      expect(server).to receive(:stop_container).with(second_container['Id']).once
+      expect(server).to receive(:stop_container).with(container['Id'], 30).once
+      expect(server).to receive(:stop_container).with(second_container['Id'], 30).once
 
       test_deploy.stop_containers(server, bindings)
     end

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -62,6 +62,13 @@ describe Centurion::DockerViaApi do
 
   it 'stops a container' do
     expect(Excon).to receive(:post).
+                     with(excon_uri + "v1.7" + "/containers/12345/stop?t=300").
+                     and_return(double(status: 204))
+    api.stop_container('12345', 300)
+  end
+
+  it 'stops a container with a custom timeout' do
+    expect(Excon).to receive(:post).
                      with(excon_uri + "v1.7" + "/containers/12345/stop?t=30").
                      and_return(double(status: 204))
     api.stop_container('12345')


### PR DESCRIPTION
Some containers take > 30 seconds to stop, so let deployment configuration
specify something longer. Keeps the 30 second default. See #32
