### PR TITLE
Automatically handle host.tld/repo/img format for image name

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -55,7 +55,7 @@ set :hosts, opts[:hosts].split(",") if opts[:hosts]
 
 # Default tag should be "latest"
 set :tag, 'latest' unless any?(:tag)
-set :docker_registry, Centurion::DockerRegistry::OFFICIAL_URL
+set :docker_registry, Centurion::DockerRegistry::OFFICIAL_URL unless any?(:docker_registry)
 
 # Specify a path to docker executable
 set :docker_path, opts[:docker_path]

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -38,7 +38,7 @@ module Centurion::DeployDSL
     require_options_keys(options,  [ :container_port ])
 
     add_to_bindings(
-      options[:host_ip] || '0.0.0.0', 
+      options[:host_ip] || '0.0.0.0',
       options[:container_port],
       port,
       options[:type] || 'tcp'

--- a/spec/docker_registry_spec.rb
+++ b/spec/docker_registry_spec.rb
@@ -9,9 +9,11 @@ describe Centurion::DockerRegistry do
     let(:repository) { 'foobar' }
     let(:tag_name) { 'arbitrary_tag' }
     let(:image_id) { 'deadbeef0000' }
+    let(:url) { any_args() }
 
     before do
       expect(Excon).to receive(:get).
+                       with(url).
                        and_return(double(status: 200, body: response))
     end
 
@@ -37,5 +39,21 @@ describe Centurion::DockerRegistry do
         expect(subject).to eq(tag_name => image_id)
       end
     end
+
+    context 'when given the official Docker registry and a repository with a host name' do
+      let(:registry_url) { Centurion::DockerRegistry::OFFICIAL_URL }
+      let(:repository) { 'example.com/foobar' }
+
+      let(:response) { <<-JSON.strip }
+        {"#{tag_name}": "#{image_id}"}
+      JSON
+
+      let(:url) { 'https://example.com/v1/repositories/foobar/tags' }
+
+      it 'fetches from the image-referenced registry' do
+        expect(subject).to eq(tag_name => image_id)
+      end
+    end
   end
+
 end


### PR DESCRIPTION
Also fix the issue where `:docker_registry` was being clobbered in `bin/centurion`
