### PR TITLE
Fixed arguments to start_new_container

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -52,6 +52,7 @@ namespace :deploy do
         fetch(:port_bindings),
         fetch(:binds),
         fetch(:env_vars),
+        fetch(:command),
         fetch(:cidfile, '/etc/cidfile')
       )
     end
@@ -65,6 +66,7 @@ namespace :deploy do
         fetch(:port_bindings),
         fetch(:binds),
         fetch(:env_vars),
+        fetch(:command),
         fetch(:cidfile, '/etc/cidfile')
       )
     end
@@ -80,6 +82,7 @@ namespace :deploy do
         fetch(:port_bindings),
         fetch(:binds),
         fetch(:env_vars),
+        fetch(:command),
         fetch(:cidfile, '/etc/cidfile')
       )
 


### PR DESCRIPTION
Looks like the call to start_new_container has the wrong number of arguments, which results in Docker trying to execute the cidfile, instead of the command parameter which is missing.
