### PR TITLE
Revert adding Cidfile

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -67,7 +67,7 @@ module Centurion::Deploy
     return false unless response
     return true if response.status >= 200 && response.status < 300
 
-    warn "Got HTTP status: #{response.status}"
+    warn "Got HTTP status: #{response.status}" 
     false
   end
 
@@ -119,39 +119,34 @@ module Centurion::Deploy
     container_config
   end
 
-  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil, command=nil, cidfile=nil)
+  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil, command=nil)
     container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, command)
-    start_container_with_config(target_server, volumes, port_bindings, container_config, cidfile)
+    start_container_with_config(target_server, volumes, port_bindings, container_config)
   end
 
-  def launch_console(target_server, image_id, port_bindings, volumes, env_vars=nil, cidfile=nil)
+  def launch_console(target_server, image_id, port_bindings, volumes, env_vars=nil)
     container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, ['/bin/bash']).merge(
       'AttachStdin' => true,
       'Tty'         => true,
       'OpenStdin'   => true,
     )
 
-    container = start_container_with_config(target_server, volumes, port_bindings, container_config, cidfile)
+    container = start_container_with_config(target_server, volumes, port_bindings, container_config)
 
     target_server.attach(container['Id'])
   end
 
   private
-
-  def start_container_with_config(target_server, volumes, port_bindings, container_config, cidfile)
+  
+  def start_container_with_config(target_server, volumes, port_bindings, container_config)
     info "Creating new container for #{container_config['Image'][0..7]}"
     new_container = target_server.create_container(container_config)
 
     host_config = {}
-
     # Map some host volumes if needed
     host_config['Binds'] = volumes if volumes && !volumes.empty?
-
     # Bind the ports
-    host_config['PortBindings'] = port_bindings
-
-    # Assign cidfile
-    host_config['ContainerIDFile'] = cidfile if cidfile
+    host_config['PortBindings'] = port_bindings 
 
     info "Starting new container #{new_container['Id'][0..7]}"
     target_server.start_container(new_container['Id'], host_config)

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -53,8 +53,7 @@ namespace :deploy do
         fetch(:image_id),
         fetch(:port_bindings),
         fetch(:binds),
-        fetch(:env_vars),
-        fetch(:cidfile, '/etc/cidfile')
+        fetch(:env_vars)
       )
     end
   end
@@ -66,8 +65,7 @@ namespace :deploy do
         fetch(:image_id),
         fetch(:port_bindings),
         fetch(:binds),
-        fetch(:env_vars),
-        fetch(:cidfile, '/etc/cidfile')
+        fetch(:env_vars)
       )
     end
   end
@@ -81,8 +79,7 @@ namespace :deploy do
         fetch(:image_id),
         fetch(:port_bindings),
         fetch(:binds),
-        fetch(:env_vars),
-        fetch(:cidfile, '/etc/cidfile')
+        fetch(:env_vars)
       )
 
       fetch(:port_bindings).each_pair do |container_port, host_ports|

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -9,8 +9,8 @@ describe Centurion::Deploy do
   let(:port)            { 8484 }
   let(:container)       { { 'Ports' => [{ 'PublicPort' => port }, 'Created' => Time.now.to_i ], 'Id' => '21adfd2ef2ef2349494a', 'Names' => [ 'name1' ] } }
   let(:endpoint)        { '/status/check' }
-  let(:test_deploy) do
-    Object.new.tap do |o|
+  let(:test_deploy) do 
+    Object.new.tap do |o| 
       o.send(:extend, Centurion::Deploy)
       o.send(:extend, Centurion::DeployDSL)
       o.send(:extend, Centurion::Logging)
@@ -84,7 +84,7 @@ describe Centurion::Deploy do
       test_deploy.stub(:warn)
       expect(test_deploy).to receive(:exit)
       expect(test_deploy).to receive(:sleep).with(0)
-
+       
       test_deploy.wait_for_http_status_ok(server, port, '/foo', 'image_id', 'chaucer', 0, 1)
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
     end
@@ -95,7 +95,7 @@ describe Centurion::Deploy do
       test_deploy.stub(:error)
       test_deploy.stub(:warn)
       expect(test_deploy).to receive(:exit)
-
+       
       test_deploy.wait_for_http_status_ok(server, port, '/foo', 'image_id', 'chaucer', 1, 0)
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
     end
@@ -229,12 +229,11 @@ describe Centurion::Deploy do
       expect(server).to receive(:start_container).with(
         'abc123456',
         {
-          'PortBindings' => bindings,
-          'ContainerIDFile' => '/etc/cidfile'
+          'PortBindings' => bindings
         }
       ).once
 
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil, '/etc/cidfile')
+      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
     end
   end
 
@@ -252,16 +251,8 @@ describe Centurion::Deploy do
       test_deploy.start_new_container(server, 'image_id', bindings, {}, nil)
     end
 
-    it 'pass cidfile to start_container_with_config method' do
-      test_deploy.stub(:container_config_for)
-
-      expect(test_deploy).to receive(:start_container_with_config).with(server, anything(), bindings, nil, '/etc/cidfile').once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil, '/etc/cidfile')
-    end
-
     it 'starts the container' do
-      expect(test_deploy).to receive(:start_container_with_config).with(server, {}, anything(), anything(), anything())
+      expect(test_deploy).to receive(:start_container_with_config).with(server, {}, anything(), anything())
 
       test_deploy.start_new_container(server, 'image_id', bindings, {})
     end
@@ -291,20 +282,18 @@ describe Centurion::Deploy do
     let(:volumes)  { nil }
     let(:env)      { nil }
     let(:command)  { nil }
-    let(:cidfile)  { nil }
 
     it 'configures the container' do
       expect(test_deploy).to receive(:container_config_for).with(server, 'image_id', bindings, env, volumes, command).once
       test_deploy.stub(:start_container_with_config)
 
-      test_deploy.start_new_container(server, 'image_id', bindings, volumes, env, command, cidfile)
+      test_deploy.start_new_container(server, 'image_id', bindings, volumes, env, command)
     end
 
     it 'augments the container_config' do
       expect(test_deploy).to receive(:start_container_with_config).with(server, volumes,
         anything(),
-        hash_including('Cmd' => [ '/bin/bash' ], 'AttachStdin' => true , 'Tty' => true , 'OpenStdin' => true),
-        anything()
+        hash_including('Cmd' => [ '/bin/bash' ], 'AttachStdin' => true , 'Tty' => true , 'OpenStdin' => true)
       ).and_return({'Id' => 'shakespeare'})
 
       test_deploy.launch_console(server, 'image_id', bindings, volumes, env)
@@ -312,7 +301,7 @@ describe Centurion::Deploy do
 
     it 'starts the console' do
       expect(test_deploy).to receive(:start_container_with_config).with(
-        server, nil, anything(), anything(), anything()
+        server, nil, anything(), anything()
       ).and_return({'Id' => 'shakespeare'})
 
       test_deploy.launch_console(server, 'image_id', bindings, volumes, env)


### PR DESCRIPTION
Cidfile doesn't work as we thought it did. It creates a cidfile on the Docker **client**, not add a cidfile into the Docker container.

This reverts PR #24 and fixes issues #38 
