### PR TITLE
Stringize values given to env_vars, for when we gsub them on output

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -11,7 +11,7 @@ module Centurion::DeployDSL
   def env_vars(new_vars)
     current = fetch(:env_vars, {})
     new_vars.each_pair do |new_key, new_value|
-      current[new_key.to_s] = new_value
+      current[new_key.to_s] = new_value.to_s
     end
     set(:env_vars, current)
   end

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -28,13 +28,15 @@ describe Centurion::DeployDSL do
     expect(DeployDSLTest.fetch(:command)).to equal(command)
   end
 
-  it 'adds new env_vars to the existing ones' do
+  it 'adds new env_vars to the existing ones, as strings' do
     DeployDSLTest.set(:env_vars, { 'SHAKESPEARE' => 'Hamlet' })
-    DeployDSLTest.env_vars('DICKENS' => 'David Copperfield')
+    DeployDSLTest.env_vars('DICKENS' => 'David Copperfield',
+                           :DICKENS_BIRTH_YEAR => 1812)
 
     expect(DeployDSLTest.fetch(:env_vars)).to include(
-      'SHAKESPEARE' => 'Hamlet',
-      'DICKENS'     => 'David Copperfield'
+      'SHAKESPEARE'        => 'Hamlet',
+      'DICKENS'            => 'David Copperfield',
+      'DICKENS_BIRTH_YEAR' => '1812'
     )
   end
 


### PR DESCRIPTION
I found that when I did:

``` ruby
  env_vars UNICORN_COUNT: 5
```

I got an exception when [this line](https://github.com/newrelic/centurion/blob/e3916e0f065158189118e2d4cfc9530661cf824e/lib/centurion/deploy.rb#L107) maps '%DOCKER_HOSTNAME%' assuming that the value will be a string.

So, this PR stringizes values when env_vars gets them. (The test also ensures that keys will be stringized, which they already were).
