### PR TITLE
Support hostnames with multiple components in custom repository addresses

### DIFF
--- a/lib/centurion/docker_registry.rb
+++ b/lib/centurion/docker_registry.rb
@@ -60,13 +60,13 @@ class Centurion::DockerRegistry
 
   def is_official_registry?(repository)
     if @base_uri == OFFICIAL_URL
-      return !repository.match(/^[a-z0-9-]+.[a-z]+\//)
+      return !repository.match(/^[a-z0-9]+[a-z0-9\-\.]+(?::[1-9][0-9]*)?\//)
     end
     false
   end
 
   def uri_for_repository_path(repository, path)
-    if repository.match(/\A([a-z0-9-]+.[a-z]+)\/(.*)\z/)
+    if repository.match(/\A([a-z0-9]+[a-z0-9\-\.]+(?::[1-9][0-9]*)?)\/(.*)\z/)
       host = $1
       short_image_name = $2
       "https://#{host}#{path.gsub(repository, short_image_name)}"

--- a/spec/docker_registry_spec.rb
+++ b/spec/docker_registry_spec.rb
@@ -42,13 +42,13 @@ describe Centurion::DockerRegistry do
 
     context 'when given the official Docker registry and a repository with a host name' do
       let(:registry_url) { Centurion::DockerRegistry::OFFICIAL_URL }
-      let(:repository) { 'example.com/foobar' }
+      let(:repository) { 'docker-reg.example.com/foobar' }
 
       let(:response) { <<-JSON.strip }
         {"#{tag_name}": "#{image_id}"}
       JSON
 
-      let(:url) { 'https://example.com/v1/repositories/foobar/tags' }
+      let(:url) { 'https://docker-reg.example.com/v1/repositories/foobar/tags' }
 
       it 'fetches from the image-referenced registry' do
         expect(subject).to eq(tag_name => image_id)


### PR DESCRIPTION
The current implementation of private repository support handles only example.com/repo format of image names. These changeset adds support for subdomains (e.g. docker.subdomain.example.com/repo) and custom port specifications (docker.example.com:45411/repo).
