### PR TITLE
passing in command as an arg to start_new_container

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -85,7 +85,8 @@ namespace :deploy do
         fetch(:image_id),
         fetch(:port_bindings),
         fetch(:binds),
-        fetch(:env_vars)
+        fetch(:env_vars),
+        fetch(:command)
       )
     end
   end


### PR DESCRIPTION
this is to fix the bug that command DSL in the rake file being ignored. This addresses Issue #58 
