### PR TITLE
Make setting skipped ports more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ are the same everywhere. Settings are per-project.
    `rolling_deployment_wait_time` is the total time Centurion will wait for
    an individual container to come up before giving up as a failure. Defaults
    to 24 attempts.
- * `rolling_deploy_skip_ports` => An array of ports (as strings) that should be
-   skipped for status checks. Status checking assumes an HTTP server is on the
-   other end and if you are deploying a container where some ports are not
-   HTTP services, this allows you to only health check the ports that are.
-   The default is an empty array.
+ * `rolling_deploy_skip_ports` => Either a single port, or an array of ports
+   that should be skipped for status checks. Status checking assumes an HTTP 
+   server is on the other end and if you are deploying a container where some 
+   ports are not HTTP services, this allows you to only health check the ports 
+   that are. The default is an empty array.
 
 ###Deploy a project to a fleet of Docker servers
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -118,7 +118,7 @@ namespace :deploy do
 
       fetch(:port_bindings).each_pair do |container_port, host_ports|
         port = host_ports.first['HostPort']
-        next if fetch(:rolling_deploy_skip_ports, []).include?(port)
+        next if Array(fetch(:rolling_deploy_skip_ports, [])).include?(port.to_i)
 
         wait_for_http_status_ok(
           server,


### PR DESCRIPTION
I've wrapped the check for skipped ports with `Array` so that a single port can be set, and called `#to_i` on the ports returned from Docker to make setting them a bit more intuitive.

You can now call `set :rolling_deploy_skip_ports, 5672` to skip a single port.
