### PR TITLE
Don't override the Docker default container binding IP address

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -38,7 +38,7 @@ module Centurion::DeployDSL
     require_options_keys(options,  [ :container_port ])
 
     add_to_bindings(
-      options[:host_ip] || '0.0.0.0',
+      options[:host_ip],
       options[:container_port],
       port,
       options[:type] || 'tcp'
@@ -79,9 +79,10 @@ module Centurion::DeployDSL
 
   def add_to_bindings(host_ip, container_port, port, type='tcp')
     set(:port_bindings, fetch(:port_bindings, {}).tap do |bindings|
-      bindings["#{container_port.to_s}/#{type}"] = [
-        {'HostIp' => host_ip, 'HostPort' => port.to_s}
-      ]
+      binding = { 'HostPort' => port.to_s }.tap do |b|
+        b['HostIp'] = host_ip if host_ip
+      end
+      bindings["#{container_port.to_s}/#{type}"] = [ binding ]
       bindings
     end)
   end

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -73,6 +73,17 @@ describe Centurion::DeployDSL do
 
       expect(DeployDSLTest).to have_key_and_value(
         :port_bindings,
+        dummy_value.merge('80/tcp' => [{ 'HostPort' => '999' }])
+      )
+    end
+
+    it 'adds new bind ports to the list with an IP binding when supplied' do
+      dummy_value = { '666/tcp' => ['value'] }
+      DeployDSLTest.set(:port_bindings, dummy_value)
+      DeployDSLTest.host_port(999, container_port: 80, host_ip: '0.0.0.0')
+
+      expect(DeployDSLTest).to have_key_and_value(
+        :port_bindings,
         dummy_value.merge('80/tcp' => [{ 'HostIp' => '0.0.0.0', 'HostPort' => '999' }])
       )
     end


### PR DESCRIPTION
I don't believe it's necessary to do this on Docker versions since at least 1.0, perhaps earlier.  The fact that we do is a holdover from ancient Docker versions which required that an IP address be passed. The net effect is that we are enforcing architectural decisions on people who use Centurion to deploy which are not required. If we don't pass the host IP, containers will bind to whatever that `dockerd` has as the default. We have "forever" supported being able to override this by passing `host_ip` on the bind line in the config. That is still supported.
