### PR TITLE
Fix RSpec deprecation warnings

### DIFF
--- a/spec/capistrano_dsl_spec.rb
+++ b/spec/capistrano_dsl_spec.rb
@@ -61,7 +61,7 @@ describe Capistrano::DSL do
       end
 
       DSLTest.set(:foo, NoAny.new)
-      DSLTest.any?(:foo).should eq('oh no')
+      expect(DSLTest.any?(:foo)).to eq('oh no')
     end
   end
 end

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -115,7 +115,7 @@ describe Centurion::DeployDSL do
   end
 
   it 'gets current tags for an image' do
-    Centurion::DockerServer.any_instance.stub(current_tags_for: [ 'foo' ])
+    allow_any_instance_of(Centurion::DockerServer).to receive(:current_tags_for).and_return([ 'foo' ])
     DeployDSLTest.set(:hosts, [ 'host1' ])
 
     expect(DeployDSLTest.get_current_tags_for('asdf')).to eq [ { server: 'host1', tags: [ 'foo'] } ]

--- a/spec/docker_server_group_spec.rb
+++ b/spec/docker_server_group_spec.rb
@@ -23,7 +23,7 @@ describe Centurion::DockerServerGroup do
   end
 
   it 'can run parallel operations' do
-    item = double('item').tap { |i| i.stub(:dummy_method) }
+    item = double('item').tap { |i| allow(i).to receive(:dummy_method) }
     expect(item).to receive(:dummy_method).twice
 
     expect { group.each_in_parallel { |host| item.dummy_method } }.not_to raise_error

--- a/spec/docker_server_spec.rb
+++ b/spec/docker_server_spec.rb
@@ -28,7 +28,7 @@ describe Centurion::DockerServer do
       it "delegates '#{method}' to #{delegate}" do
         dummy_result = double
         dummy_delegate = double(method => dummy_result)
-        server.stub(delegate => dummy_delegate)
+        allow(server).to receive(delegate).and_return(dummy_delegate)
         expect(dummy_delegate).to receive(method)
         expect(server.send(method)).to be(dummy_result)
       end
@@ -37,7 +37,7 @@ describe Centurion::DockerServer do
 
   it 'returns tags associated with an image' do
     image_names = %w[target:latest target:production other:latest]
-    server.stub(ps: image_names.map {|name| { 'Image' => name } })
+    allow(server).to receive(:ps).and_return(image_names.map {|name| { 'Image' => name } })
     expect(server.current_tags_for('target')).to eq(%w[latest production])
   end
 end

--- a/spec/dogestry_spec.rb
+++ b/spec/dogestry_spec.rb
@@ -14,44 +14,44 @@ describe Centurion::Dogestry do
 
   describe '#aws_access_key_id' do
     it 'returns correct value' do
-      registry.aws_access_key_id.should == dogestry_options[:aws_access_key_id]
+      expect(registry.aws_access_key_id).to eq(dogestry_options[:aws_access_key_id])
     end
   end
 
   describe '#aws_secret_key' do
     it 'returns correct value' do
-      registry.aws_secret_key.should == dogestry_options[:aws_secret_key]
+      expect(registry.aws_secret_key).to eq(dogestry_options[:aws_secret_key])
     end
   end
 
   describe '#s3_bucket' do
     it 'returns correct value' do
-      registry.s3_bucket.should == dogestry_options[:s3_bucket]
+      expect(registry.s3_bucket).to eq(dogestry_options[:s3_bucket])
     end
   end
 
   describe '#s3_region' do
     it 'returns correct default value' do
-      registry.s3_region.should == "us-east-1"
+      expect(registry.s3_region).to eq("us-east-1")
     end
   end
 
   describe '#s3_url' do
     it 'returns correct value' do
-      registry.s3_url.should == "s3://#{registry.s3_bucket}/?region=#{registry.s3_region}"
+      expect(registry.s3_url).to eq("s3://#{registry.s3_bucket}/?region=#{registry.s3_region}")
     end
   end
 
   describe '#exec_command' do
     it 'returns correct value' do
-      registry.exec_command('pull', repo).should start_with('dogestry')
+      expect(registry.exec_command('pull', repo)).to start_with('dogestry') 
     end
   end
 
   describe '#which' do
     it 'finds dogestry command line' do
       allow(File).to receive(:executable?).and_return(true)
-      registry.which('dogestry').should_not == nil
+      expect(registry.which('dogestry')).to_not be_nil
     end
   end
 end

--- a/spec/support/matchers/capistrano_dsl_matchers.rb
+++ b/spec/support/matchers/capistrano_dsl_matchers.rb
@@ -3,11 +3,11 @@ RSpec::Matchers.define :have_key_and_value do |expected_key, expected_value|
     actual.env[actual.current_environment].has_key?(expected_key.to_sym) && (actual.fetch(expected_key.to_sym) == expected_value)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected that #{actual.env[actual.current_environment].keys.inspect} would include #{expected_key.inspect} with value #{expected_value.inspect}"
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected that #{actual.env[actual.current_environment].keys.join(', ')} would not include #{expected_key.inspect} with value #{expected_value.inspect}"
   end
 end


### PR DESCRIPTION
I tried to keep the meaning of the tests the same, while updating to use the new RSpec syntax.
