### PR TITLE
Add support for naming containers when deploying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ IP address (the equivalent of `docker run --dns 172.17.42.1 ...`) like this:
   end
 ```
 
+If you want to name your container, use the `name` DSL item. The
+actual name for the created container will have a random hex string
+appended, to avoid name conflicts when you repeatedly deploy an image:
+```ruby
+  task :common do
+    set :name, 'backend'
+    # ...
+  end
+```
+With this, the container will be named something like `backend-4f692997`.
+
 ### Interpolation
 
 Currently there is one special string for interpolation that can be added to

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -140,7 +140,7 @@ module Centurion::Deploy
 
   def start_container_with_config(target_server, volumes, port_bindings, container_config)
     info "Creating new container for #{container_config['Image'][0..7]}"
-    new_container = target_server.create_container(container_config)
+    new_container = target_server.create_container(container_config, fetch(:name))
 
     host_config = {}
     # Map some host volumes if needed

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -1,6 +1,7 @@
 require 'excon'
 require 'json'
 require 'uri'
+require 'securerandom'
 
 module Centurion; end
 
@@ -60,10 +61,11 @@ class Centurion::DockerViaApi
     true
   end
 
-  def create_container(configuration)
+  def create_container(configuration, name = nil)
     path = "/v1.10/containers/create"
     response = Excon.post(
       @base_uri + path,
+      :query => name ? {:name => "#{name}-#{SecureRandom.hex(4)}"} : nil,
       :body => configuration.to_json,
       :headers => { "Content-Type" => "application/json" }
     )

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -229,6 +229,7 @@ describe Centurion::Deploy do
       allow(server).to receive(:inspect_container)
 
       allow(test_deploy).to receive(:fetch).with(:custom_dns).and_return('8.8.8.8')
+      allow(test_deploy).to receive(:fetch).with(:name).and_return(nil)
 
       expect(server).to receive(:start_container).with(
         'abc123456',
@@ -264,6 +265,7 @@ describe Centurion::Deploy do
 
     it 'ultimately asks the server object to do the work' do
       allow(test_deploy).to receive(:fetch).with(:custom_dns).and_return(nil)
+      allow(test_deploy).to receive(:fetch).with(:name).and_return('app1')
 
       expect(server).to receive(:create_container).with(
         hash_including(
@@ -273,7 +275,8 @@ describe Centurion::Deploy do
           'Cmd' => command,
           'Env' => ['FOO=BAR'],
           'Volumes' => {'/bar' => {}},
-        )
+        ),
+        'app1'
       ).and_return(container)
 
       expect(server).to receive(:start_container)

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -43,10 +43,23 @@ describe Centurion::DockerViaApi do
     configuration = double(:to_json => configuration_as_json)
     expect(Excon).to receive(:post).
                          with(excon_uri + "v1.10" + "/containers/create",
+                              query: nil,
                               body: configuration_as_json,
                               headers: {'Content-Type' => 'application/json'}).
                          and_return(double(body: json_string, status: 201))
     api.create_container(configuration)
+  end
+
+  it 'creates a container with a name' do
+    configuration_as_json = double
+    configuration = double(:to_json => configuration_as_json)
+    expect(Excon).to receive(:post).
+                         with(excon_uri + "v1.10" + "/containers/create",
+                              query: {:name => match(/^app1-[a-f0-9]+$/)},
+                              body: configuration_as_json,
+                              headers: {'Content-Type' => 'application/json'}).
+                         and_return(double(body: json_string, status: 201))
+    api.create_container(configuration, 'app1')
   end
 
   it 'starts a container' do


### PR DESCRIPTION
 When running several containers based on a single image on one host, it's useful to be able to name them.

For instance, when running four containers doing a processing job, it's nicer to have them named `backend1`, `backend2`, `backend3` and `backend4` instead of just having generated names.

Another example are images that can perform different tasks depending on configuration (like environment variables), so the containers could be named `backend-encoding`, `backend-multiplexing`, `backend-decoding` and so on.
