### PR TITLE
treat docker-host more consistently when talking to dogestry

### DIFF
--- a/lib/centurion/dogestry.rb
+++ b/lib/centurion/dogestry.rb
@@ -52,10 +52,6 @@ class Centurion::Dogestry
     "s3://#{s3_bucket}/?region=#{s3_region}"
   end
 
-  def docker_host
-    @options[:docker_host] || 'tcp://localhost:2375'
-  end
-
   def set_envs(docker_host)
     ENV['DOCKER_HOST'] = docker_host
     ENV['AWS_ACCESS_KEY'] = aws_access_key_id
@@ -70,9 +66,9 @@ class Centurion::Dogestry
     command
   end
 
-  def download_image_to_temp_dir(repo, local_dir)
+  def download_image_to_temp_dir(repo, local_dir, docker_host)
     validate_before_exec
-    set_envs("")
+    set_envs(docker_host)
 
     flags = "-tempdir #{File.expand_path(local_dir)}"
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -53,7 +53,7 @@ namespace :deploy do
       Dir.mktmpdir("dogestry") do |local_dir|
 
         info "** Downloading image(#{fetch(:image)}:#{fetch(:tag)}) from S3 to local directory"
-        registry.download_image_to_temp_dir("#{fetch(:image)}:#{fetch(:tag)}", local_dir)
+        registry.download_image_to_temp_dir("#{fetch(:image)}:#{fetch(:tag)}", local_dir, ENV["DOCKER_HOST"])
 
         # Upload image from local /tmp/directory to specified Docker hosts
         target_servers = Centurion::DockerServerGroup.new(fetch(:hosts), fetch(:docker_path))


### PR DESCRIPTION
Currently, when Centurion runs the dogestry command to download an image, it passes an empty DOCKER_HOST environment variable; dogestry then defaults to tcp://localhost:2375, which doesn't work with newer versions of boot2docker that use a 192.168.59.x address.

This PR makes the Dogestry class handle the docker-host value a little more consistently; it removes the docker_host method that would also always return the default value (coincidentally, the same value dogestry uses).

@relistan @didip 
