### PR TITLE
Use the dogestry pull command to pull to multiple hosts.

### DIFF
--- a/lib/centurion/dogestry.rb
+++ b/lib/centurion/dogestry.rb
@@ -52,12 +52,7 @@ class Centurion::Dogestry
     "s3://#{s3_bucket}/?region=#{s3_region}"
   end
 
-  def docker_host
-    @options[:docker_host] || 'tcp://localhost:2375'
-  end
-
-  def set_envs(docker_host)
-    ENV['DOCKER_HOST'] = docker_host
+  def set_envs()
     ENV['AWS_ACCESS_KEY'] = aws_access_key_id
     ENV['AWS_SECRET_KEY'] = aws_secret_key
 
@@ -70,22 +65,14 @@ class Centurion::Dogestry
     command
   end
 
-  def download_image_to_temp_dir(repo, local_dir)
+  def pull(repo, pull_hosts)
     validate_before_exec
-    set_envs("")
+    set_envs()
 
-    flags = "-tempdir #{File.expand_path(local_dir)}"
+    hosts = pull_hosts.join(",")
+    flags = "-pullhosts #{hosts}"
 
-    echo(exec_command('download', repo, flags=flags))
+    echo(exec_command('pull', repo, flags))
   end
 
-  def upload_temp_dir_image_to_docker(repo, local_dir, docker_host)
-    validate_before_exec
-    set_envs(docker_host)
-
-    command = "dogestry upload #{local_dir} #{repo}"
-    info "Executing: #{command}"
-
-    echo(command)
-  end
 end

--- a/spec/dogestry_spec.rb
+++ b/spec/dogestry_spec.rb
@@ -48,6 +48,13 @@ describe Centurion::Dogestry do
     end
   end
 
+ describe '#pull' do
+   it 'returns correct value' do
+     expect(registry).to receive(:echo).with("dogestry #{flags} pull #{registry.s3_url} #{repo}")
+     registry.pull(repo, pull_hosts)
+   end
+ end
+
   describe '#which' do
     it 'finds dogestry command line' do
       allow(File).to receive(:executable?).and_return(true)


### PR DESCRIPTION
Now that the `dogestry pull` command can pull to multiple docker hosts
(see https://github.com/dogestry/dogestry/pull/6), we can replace the previous two-step process
(`download_image_to_temp_dir()`, and then `upload_temp_dir_image_to_docker()`)
with a single call to `pull()`.

Also, since you can now pass the docker hosts to `dogestry pull` as command
line arguments, there's no longer a need for setting the `DOCKER_HOST` environment
variable before calling dogestry.

cc: @didip @relistan  @bryannewrelic 
