### PR TITLE
Limit cgroup resources via Centurion

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -87,13 +87,15 @@ module Centurion::Deploy
     end
   end
 
-  def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil, command=nil)
+  def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil, command=nil, memory=nil, cpu_shares=nil)
     container_config = {
       'Image'        => image_id,
       'Hostname'     => target_server.hostname,
     }
 
     container_config.merge!('Cmd' => command) if command
+    container_config.merge!('Memory' => memory) if memory
+    container_config.merge!('CpuShares' => cpu_shares) if cpu_shares
 
     if port_bindings
       container_config['ExposedPorts'] ||= {}
@@ -119,8 +121,8 @@ module Centurion::Deploy
     container_config
   end
 
-  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil, command=nil)
-    container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, command)
+  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil, command=nil, memory=nil, cpu_shares=nil)
+    container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, command, memory, cpu_shares)
     start_container_with_config(target_server, volumes, port_bindings, container_config)
   end
 

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -4,6 +4,8 @@ module Centurion; end
 
 module Centurion::Deploy
   FAILED_CONTAINER_VALIDATION = 100
+  INVALID_CGROUP_CPUSHARES_VALUE = 101
+  INVALID_CGROUP_MEMORY_VALUE = 102
 
   def stop_containers(target_server, port_bindings, timeout = 30)
     public_port    = public_port_for(port_bindings)
@@ -71,6 +73,17 @@ module Centurion::Deploy
     false
   end
 
+  def is_a_uint64?(value)
+    result = false
+    if !value.is_a? Integer
+      return result
+    end
+    if value < 0 || value > 0xFFFFFFFFFFFFFFFF
+      return result
+    end
+    return true
+  end
+
   def wait_for_load_balancer_check_interval
     sleep(fetch(:rolling_deploy_check_interval, 5))
   end
@@ -88,6 +101,17 @@ module Centurion::Deploy
   end
 
   def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil, command=nil, memory=nil, cpu_shares=nil)
+
+    if memory && ! is_a_uint64?(memory) 
+      error "Invalid value for CGroup memory constraint: #{memory}, value must be a between 0 and 18446744073709551615"
+      exit(INVALID_CGROUP_MEMORY_VALUE)
+    end
+
+    if cpu_shares && ! is_a_uint64?(cpu_shares)
+      error "Invalid value for CGroup CPU constraint: #{cpu_shares}, value must be between 0 and 18446744073709551615"
+      exit(INVALID_CGROUP_CPUSHARES_VALUE)
+    end
+
     container_config = {
       'Image'        => image_id,
       'Hostname'     => target_server.hostname,

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -22,6 +22,14 @@ module Centurion::DeployDSL
     set(:hosts, current)
   end
 
+  def memory(memory)
+    set(:memory, memory)
+  end
+
+  def cpu_shares(cpu_shares)
+    set(:cpu_shares, cpu_shares)
+  end
+
   def command(command)
     set(:command, command)
   end

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -98,7 +98,9 @@ namespace :deploy do
         fetch(:port_bindings),
         fetch(:binds),
         fetch(:env_vars),
-        fetch(:command)
+        fetch(:command),
+        fetch(:memory),
+        fetch(:cpu_shares)
       )
     end
   end
@@ -125,7 +127,9 @@ namespace :deploy do
         fetch(:port_bindings),
         fetch(:binds),
         fetch(:env_vars),
-        fetch(:command)
+        fetch(:command),
+        fetch(:memory),
+        fetch(:cpu_shares)
       )
 
       skip_ports = Array(fetch(:rolling_deploy_skip_ports, [])).map(&:to_s)

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -212,16 +212,28 @@ describe Centurion::Deploy do
     end
 
     context 'when cgroup limits are specified' do
-      let(:memory) { "10000000" }
-      let(:cpu_shares) { "1234" }
+      let(:memory) { 10000000 }
+      let(:cpu_shares) { 1234 }
 
       it 'sets cgroup limits in the config' do
         config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, cpu_shares)
 
         expect(config).to be_a(Hash)
         expect(config.keys).to match_array(%w{ Hostname Image Memory CpuShares })
-        expect(config['Memory']).to eq("10000000")
-        expect(config['CpuShares']).to eq("1234")
+        expect(config['Memory']).to eq(10000000)
+        expect(config['CpuShares']).to eq(1234)
+      end
+
+      it 'throws a fatal error value for Cgroup Memory limit is invalid' do
+        expect { config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, "I like pie", cpu_shares) }.to terminate.with_code(102)
+        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, -100, cpu_shares) }.to terminate.with_code(102)
+        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, 0xFFFFFFFFFFFFFFFFFF, cpu_shares) }.to terminate.with_code(102)
+      end
+
+      it 'throws a fatal error value for Cgroup CPU limit is invalid' do
+        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, "I like pie") }.to terminate.with_code(101)
+        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, -100) }.to terminate.with_code(101)
+        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, 0xFFFFFFFFFFFFFFFFFF) }.to terminate.with_code(101)
       end
     end
   end

--- a/spec/support/matchers/exit_code_matches.rb
+++ b/spec/support/matchers/exit_code_matches.rb
@@ -1,0 +1,38 @@
+# https://gist.github.com/mmasashi/58bd7e2668836a387856
+RSpec::Matchers.define :terminate do |code|
+  actual = nil
+ 
+  def supports_block_expectations?
+    true
+  end
+ 
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual and actual == status_code
+  end
+ 
+  chain :with_code do |status_code|
+    @status_code = status_code
+  end
+ 
+  failure_message_for_should do |block|
+    "expected block to call exit(#{status_code}) but exit" +
+      (actual.nil? ? " not called" : "(#{actual}) was called")
+  end
+ 
+  failure_message_for_should_not do |block|
+    "expected block not to call exit(#{status_code})"
+  end
+ 
+  description do
+    "expect block to call exit(#{status_code})"
+  end
+ 
+  def status_code
+    @status_code ||= 0
+  end
+end


### PR DESCRIPTION
@relistan Please review
 
The memory and cpu_shares keyvals will get picked up from the project rakefiles and passed to the Docker API.

Example:
````
namespace :environment do
  task :common do
    set :image, 'quay.io/newrelic/cgroup-test'
  end
  desc 'Production environment'
  task :production => :common do
    set_current_environment(:production)
    host_port 17100, container_port: 80
    host 'hostname.example.com'
    memory 1000000000 
    cpu_shares 1000
  end
end
````