### PR TITLE
Finding containers by name

### DIFF
--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -34,10 +34,18 @@ class Centurion::DockerServer
 
   def find_containers_by_public_port(public_port, type='tcp')
     ps.select do |container|
-      if container['Ports']
-        container['Ports'].find do |port|
-          port['PublicPort'] == public_port.to_i && port['Type'] == type
-        end
+      next unless container && container['Ports']
+      container['Ports'].find do |port|
+        port['PublicPort'] == public_port.to_i && port['Type'] == type
+      end
+    end
+  end
+
+  def find_containers_by_name(wanted_name)
+    ps.select do |container|
+      next unless container && container['Names']
+      container['Names'].find do |name|
+        name =~ /\A\/#{wanted_name}(-[a-f0-9]{7})?\Z/
       end
     end
   end

--- a/lib/centurion/version.rb
+++ b/lib/centurion/version.rb
@@ -1,3 +1,3 @@
 module Centurion
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end


### PR DESCRIPTION
Adds the basic ability to find containers by name. By itself it doesn't change behavior, but it's the first piece of getting naming to be first class in Centurion.

Adds new method to `DockerServer.find_containers_by_name` which supports the name+hash format we now support natively. Also adds tests for existing `DockerServer.find_containers_by_port`

cc @amjith @didip @toffer 