### PR TITLE
Add a new task to get a local shell with env vars set

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,11 @@ end
 Development
 -----------
 
+Centurion supports a few features to make development easier when
+building your deployment tooling or debugging your containers.
+
+#### Overriding Environment Variables
+
 Sometimes when you're doing development you want to try out some configuration
 settings in environment variables that aren't in the config yet. Or perhaps you
 want to override existing settings to test with. You can provide the
@@ -440,6 +445,24 @@ Centurion is aimed at repeatable deployments so we don't recommend that you use
 this functionality for production deployments. It will work, but it means that
 the config is not the whole source of truth for your container configuration.
 Caveat emptor.
+
+#### Exporting Environment Variables Locally
+
+Sometimes you need to test how your code works inside the container and you
+need to have all of your configuration exported. Centurion includes an action
+that will let you do that. It exports all of your environment settings for the
+environment you specify. It then partially sanitizes them to preserve things
+like `rbenv` settings. Then it executes `/bin/bash` locally.
+
+The action is named `dev:export_only` and you call it like this:
+
+```bash
+$ bundle exec centurion -e development -p testing_project -a dev:export_only
+$ bundle exec rake spec
+```
+
+It's important to note that the second line is actually being invoked with new
+environment exported.
 
 Future Additions
 ----------------

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -25,6 +25,18 @@ end
 
 task :stop => ['deploy:stop']
 
+namespace :dev do
+  task :export_only do
+    # This removes the known-to-be-problematic bundler env
+    # vars but doesn't try to sanitize the whole ENV. Doing
+    # so breaks things like rbenv which we need to use when
+    # testing. A /bin/bash -l will help further clean it up.
+    ENV.reject! { |(var, val)| var =~ /^BUNDLE_/ }
+    fetch(:env_vars).each { |(var, value)| ENV[var] = value }
+    exec fetch(:development_shell, '/bin/bash -l')
+  end
+end
+
 namespace :deploy do
   include Centurion::Deploy
 
@@ -250,4 +262,5 @@ namespace :deploy do
 
     invoke 'deploy'
   end
+
 end


### PR DESCRIPTION
This will run a local shell or whatever `:development_shell` is set to on the local machine with the environment variables all set by Centurion. It does a little bit to clean up `ENV` but doesn't try to sanitize the whole thing or useful things like `rbenv` stop working. It's useful for testing things in development mode.  I use it like this:

```bash
$ bundle exec centurion -e development -p testing_project -a dev:export_only
$ bundle exec rake spec
```

Before merging I'll add a README.

cc @didip @amjith @bryannewrelic 