### PR TITLE
Name all containers by default

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -55,6 +55,7 @@ invoke("environment:#{opts[:environment]}")
 set :image, opts[:image] if opts[:image]
 set :tag,   opts[:tag] if opts[:tag]
 set :hosts, opts[:hosts].split(",") if opts[:hosts]
+set :name,  opts[:project].gsub(/_/, '-')
 
 # Override environment variables when specified
 if opts[:override_env]


### PR DESCRIPTION
This (one line!) change will cause all containers to be deployed with a name that matches the name of the project as passed on the command line. You can still override the name yourself in your config if you want to use something else. The impact of this is that all containers will have a Centurion-created name rather than a Docker default name like "angry_torvalds".

So if we have an application where the config file is `config/centurion/awesome_project.rake` and the deployment is triggered like:

```bash
$ bin/centurion -p awesome_project -e staging -a rolling_deploy
```
Then the container will end up being named `awesome-project-bae45efa2f78d5`, with that last bit being a random 14 digits of hex, per the normal behavior for a Centurion container name.

cc @didip @actaeon @wulczer @amjith @toffer 