### PR TITLE
Interpolate host IP address into environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,11 @@ docs](https://docs.docker.com/reference/run/#runtime-constraints-on-cpu-and-memo
 
 ### Interpolation
 
-Currently there is one special string for interpolation that can be added to
-any `env_var` value in the DSL. `%DOCKER_HOSTNAME%` will be replaced with the
-current server's hostname in the environment variable at deployment time.
+Currently there a couple of special strings for interpolation that can be added
+to any `env_var` value in the DSL. `%DOCKER_HOSTNAME%` will be replaced with
+the current server's hostname in the environment variable at deployment time.
+Also `%DOCKER_HOST_IP%` will be replaced with the *public* IP address of the
+Docker server using a `getaddrinfo` call on the client.
 
 ### Use TLS certificate
 


### PR DESCRIPTION
This will add a second string that is interpolated into `env_vars` calls. Anywhere that a value of an environment variable contains `%DOCKER_HOST_IP%` it will be replaced with the public address of the Docker server, as determined by a `getaddrinfo` call using the current server hostname as specified in the `host` directive of the config.

cc @jessedearing @didip 