### PR TITLE
Offer dry-run capability

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -33,6 +33,7 @@ opts = Trollop::options do
   opt :registry_user,    'user for registry auth',               type: String, short: :none
   opt :registry_password,'password for registry auth',           type: String, short: :none
   opt :override_env,     'override environment variables, comma separated', type: String
+  opt :dry_run,          'print out docker command do run',      type: :flag, default: false, short: :none
 end
 
 set_current_environment(opts[:environment].to_sym)
@@ -77,4 +78,9 @@ set :registry_user, opts[:registry_user] if opts[:registry_user]
 set :registry_password, opts[:registry_password] if opts[:registry_password]
 
 invoke('centurion:setup')
+if opts[:dry_run] 
+  Centurion::Mock.new(env).run
+  exit
+end
+
 invoke(opts[:action])

--- a/lib/centurion/mock.rb
+++ b/lib/centurion/mock.rb
@@ -1,0 +1,49 @@
+module Centurion
+  class Mock
+    def initialize(opts)
+      environment = opts[:current_environment]
+      @options = opts[environment]
+    end
+
+    def run
+      require 'pry-byebug'
+
+      result = hosts.map do |host|
+        string = "docker -H=tcp://#{host}:2375 run"
+
+        string << environment_vars unless env_vars.empty?
+        string << ports_vars unless ports_vars.empty?
+      end.join("\n\n\n ******* \n\n\n")
+      puts "#{result}"
+    end
+
+    private
+
+    attr_reader :options
+
+
+    def env_vars
+      options[:env_vars]
+    end
+
+    def environment_vars
+      env_vars.reduce('') { |string, (k, v)| " -e #{k.split('"')[0]}='#{v}'#{string}" }.rstrip
+    end
+
+    def ports
+      options[:port_bindings]
+    end
+
+    def hosts
+      options[:hosts]
+    end
+
+    def ports_vars
+      ports.reduce('') do |string, (host_port_protocol, container_port)|
+        h = host_port_protocol.split('/')
+        c = container_port.first['HostPort']
+        " -p #{h[0]}:#{c}/#{h[1]}#{string}"
+      end.rstrip
+    end
+  end
+end


### PR DESCRIPTION

@relistan @didip @poe
This is a work in progress, and was wondering if it was worth it or not to have me continuing, testing, etc...
I've had this need a few times and was wondering what you thought of it.

------
Offer a dry-run possibility. This would allow people who want to try
customizing a docker command on a host to acquire all environment
variables and other configuration and then run docker from command line.

It's useful if they want to run a different command that is not in their
rake file, mount a volume not defined yet, or even just tweak a bit what
they have.