### PR TITLE
Add environment to container name

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -55,7 +55,7 @@ invoke("environment:#{opts[:environment]}")
 set :image, opts[:image] if opts[:image]
 set :tag,   opts[:tag] if opts[:tag]
 set :hosts, opts[:hosts].split(",") if opts[:hosts]
-set :name,  opts[:project].gsub(/_/, '-')
+set :name,  "#{opts[:project].gsub(/_/, '-')}-#{opts[:environment]}"
 
 # Override environment variables when specified
 if opts[:override_env]


### PR DESCRIPTION
It's helpful for logging purposes to distinguish between different deployment environments, so add that to the container name, like "project-staging".