### PR TITLE
Use same TLS defaults for docker API as for docker CLI

### DIFF
--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -7,7 +7,7 @@ module Centurion; end
 
 class Centurion::DockerViaApi
   def initialize(hostname, port, tls_args = {})
-    @tls_args = tls_args # Required by tls_enable?
+    @tls_args = default_tls_args(tls_args[:tls]).merge(tls_args.reject { |k, v| v.nil? }) # Required by tls_enable?
     @base_uri = "http#{'s' if tls_enable?}://#{hostname}:#{port}"
 
     configure_excon_globally
@@ -141,5 +141,17 @@ class Centurion::DockerViaApi
     Excon.defaults[:nonblock]        = false
     Excon.defaults[:tcp_nodelay]     = true
     Excon.defaults[:ssl_ca_file]     = @tls_args[:tlscacert]
+  end
+
+  def default_tls_args(tls_enabled)
+    if tls_enabled
+      {
+          tlscacert: File.expand_path('~/.docker/ca.pem'),
+          tlscert: File.expand_path('~/.docker/cert.pem'),
+          tlskey: File.expand_path('~/.docker/key.pem')
+      }
+    else
+      {}
+    end
   end
 end

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -237,6 +237,21 @@ describe Centurion::DockerViaApi do
     end
   end
 
+   context 'with default TLS certificates' do
+    let(:excon_uri) { "https://#{hostname}:#{port}/" }
+    let(:tls_args)  { { tls: true } }
+    let(:api)       { Centurion::DockerViaApi.new(hostname, port, tls_args) }
+
+    it 'lists processes' do
+      expect(Excon).to receive(:get).
+                       with(excon_uri + 'v1.7/containers/json',
+                            client_cert: File.expand_path('~/.docker/cert.pem'),
+                            client_key: File.expand_path('~/.docker/key.pem')).
+                       and_return(double(body: json_string, status: 200))
+      expect(api.ps).to eq(json_value)
+    end
+  end
+
   def inspected_container_on_port(id, port)
     {
       "Id" => id.to_s,


### PR DESCRIPTION
When you just `set :tls, true` than docker invocations via CLI will use the default certificates from `~/.docker`, but invocation via API using Excon will fail because no defaults are provided.