### PR TITLE
Allow custom health checks

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -19,10 +19,10 @@ module Centurion::Deploy
     end
   end
 
-  def wait_for_http_status_ok(target_server, port, endpoint, image_id, tag, sleep_time=5, retries=12)
+  def wait_for_health_check_ok(health_check_method, target_server, port, endpoint, image_id, tag, sleep_time=5, retries=12)
     info 'Waiting for the port to come up'
     1.upto(retries) do
-      if container_up?(target_server, port) && http_status_ok?(target_server, port, endpoint)
+      if container_up?(target_server, port) && health_check_method.call(target_server, port, endpoint)
         info 'Container is up!'
         break
       end
@@ -31,7 +31,7 @@ module Centurion::Deploy
       sleep(sleep_time)
     end
 
-    unless http_status_ok?(target_server, port, endpoint)
+    unless health_check_method.call(target_server, port, endpoint)
       error "Failed to validate started container on #{target_server}:#{port}"
       exit(FAILED_CONTAINER_VALIDATION)
     end

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -80,6 +80,11 @@ module Centurion::DeployDSL
     set(:registry, type.to_s)
   end
 
+  def health_check(method)
+   abort("Health check expects a callable (lambda, proc, method), but #{method.class} was specified")  unless method.respond_to?(:call)
+   set(:health_check, method)
+  end
+
   private
 
   def build_server_group

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -131,7 +131,8 @@ namespace :deploy do
         port = host_ports.first['HostPort']
         next if skip_ports.include?(port)
 
-        wait_for_http_status_ok(
+        wait_for_health_check_ok(
+          fetch(:health_check, method(:http_status_ok?)),
           server,
           port,
           fetch(:status_endpoint, '/'),

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -81,7 +81,7 @@ describe Centurion::Deploy do
       allow(test_deploy).to receive(:container_up?).and_return(true)
       allow(test_deploy).to receive(:http_status_ok?).and_return(true)
 
-      test_deploy.wait_for_http_status_ok(server, port, '/foo', 'image_id', 'chaucer')
+      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, port, '/foo', 'image_id', 'chaucer')
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
       expect(test_deploy).to have_received(:info).with('Container is up!')
     end
@@ -93,7 +93,7 @@ describe Centurion::Deploy do
       expect(test_deploy).to receive(:exit)
       expect(test_deploy).to receive(:sleep).with(0)
 
-      test_deploy.wait_for_http_status_ok(server, port, '/foo', 'image_id', 'chaucer', 0, 1)
+      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, port, '/foo', 'image_id', 'chaucer', 0, 1)
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
     end
 
@@ -104,7 +104,7 @@ describe Centurion::Deploy do
       allow(test_deploy).to receive(:warn)
       expect(test_deploy).to receive(:exit)
 
-      test_deploy.wait_for_http_status_ok(server, port, '/foo', 'image_id', 'chaucer', 1, 0)
+      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, port, '/foo', 'image_id', 'chaucer', 1, 0)
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
     end
   end


### PR DESCRIPTION
This patch allows swapping the default health check with a custom check. This should also address cases like https://github.com/newrelic/centurion/issues/96

You can use a custom health check by specifying a callable object (anything that responds to :call), e.g. a Proc, lambda, or method. This method will be invoked with the host url, the port that needs to be checked, and the specified endpoint(via `set(:status_endpoint, '/somewhere/else')`). If the port is  ready, health check should return a truthy value, falsey otherwise. Here's an example of a custom health check that verifies that an elasticsearch node is up and has joined the cluster.

````ruby
def cluster_green?(target_server, port, endpoint)
  response = begin
    Excon.get("http://#{target_server.hostname}:#{port}#{endpoint}")
  rescue Excon::Errors::SocketError
    warn "Elasticsearch node not yet up"
    nil
  end

  return false unless response
  !JSON.parse(response)['timed_out']
end

task :production => :common do
  set_current_environment(:production)
  set :status_endpoint, "/_cluster/health?wait_for_status=green&wait_for_nodes=2"
  health_check method(:cluster_green?)
  host_port 9200, container_port: 9200
  host 'es-01.example.com'
  host 'es-02.example.com'
end
````
