### PR TITLE
Allow host specific configuration overrides

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -2,8 +2,40 @@ require_relative 'docker_server_group'
 require 'uri'
 
 module Centurion::DeployDSL
+  class PerHostConfiguration
+    include Centurion::DeployDSL
+
+    attr_reader :params
+
+    def initialize(hostname)
+      @params = {}
+      set(:host, hostname)
+    end
+
+    def set(key, value)
+      @params[key] = value
+    end
+
+    def fetch(key, default)
+      @params[key] || default
+    end
+  end
+
   def on_each_docker_host(&block)
-    build_server_group.tap { |hosts| hosts.each { |host| block.call(host) } }
+    global_config = env[current_environment]
+
+    fetch(:per_host_configs, []).each do |host_config|
+      config = global_config.merge(host_config)
+      host = Centurion::DockerServer.new(config.fetch(:host), fetch(:docker_path), build_tls_params)
+      info "----- Connecting to Docker on #{config.fetch(:host)} -----"
+      block.call(host, config)
+    end
+
+    fetch(:hosts, []).each do |host|
+      host = Centurion::DockerServer.new(host, fetch(:docker_path), build_tls_params)
+      info "----- Connecting to Docker on #{host} -----"
+      block.call(host, global_config)
+    end
   end
 
   def env_vars(new_vars)
@@ -14,10 +46,18 @@ module Centurion::DeployDSL
     set(:env_vars, current)
   end
 
-  def host(hostname)
-    current = fetch(:hosts, [])
-    current << hostname
-    set(:hosts, current)
+  def host(hostname, &block)
+    if block
+      per_host = PerHostConfiguration.new(hostname)
+      per_host.instance_exec(&block)
+      configurations = fetch(:per_host_configs, [])
+      configurations << per_host.params
+      set(:per_host_configs, configurations)
+    else
+      current = fetch(:hosts, [])
+      current << hostname
+      set(:hosts, current)
+    end
   end
 
   def memory(memory)
@@ -83,8 +123,8 @@ module Centurion::DeployDSL
   private
 
   def build_server_group
-    hosts, docker_path = fetch(:hosts, []), fetch(:docker_path)
-    Centurion::DockerServerGroup.new(hosts, docker_path, build_tls_params)
+    hosts = fetch(:hosts, []) + fetch(:per_host_configs, []).map(&:host)
+    Centurion::DockerServerGroup.new(hosts, fetch(:docker_path), build_tls_params)
   end
 
   def add_to_bindings(host_ip, container_port, port, type='tcp')

--- a/lib/centurion/docker_server_group.rb
+++ b/lib/centurion/docker_server_group.rb
@@ -11,8 +11,8 @@ class Centurion::DockerServerGroup
 
   def initialize(hosts, docker_path, tls_params = {})
     raise ArgumentError.new('Bad Host list!') if hosts.nil? || hosts.empty?
-    @hosts = hosts.map do |hostname|
-      Centurion::DockerServer.new(hostname, docker_path, tls_params)
+    @hosts = hosts.map do |host|
+      Centurion::DockerServer.new(host, docker_path, tls_params)
     end
   end
 


### PR DESCRIPTION
We've hit several cases where we need to provide container-specific configuration. This specific use-case was also mentioned here https://github.com/newrelic/centurion/issues/18#issuecomment-50802349.

I've implemented it as an (optional) block to `host`, where you can use the centurion dsl to define options that will be scoped to that container only. Anything that is set outside the `host` block is considered global configuration and merged with the container-specific options.

This is just a quick hack to show how it could work and to start the discussion (although I'm doing **successful rolling deploys** with it). I'm willing to take it further, if this PR has a chance of being merged.

This is an example from our redis-cluster deploy where we spin 2 containers on each host to better utilize resources.

````ruby
task :production => :common do
    set :tlsverify, true
    set_current_environment(:production)
    host('redis-01.example.com') { host_port 8000, container_port: 6379; host_volume '/volumes/redis.8000', container_volume: '/data' }
    host('redis-01.example.com') { host_port 8001, container_port: 6379; host_volume '/volumes/redis.8001', container_volume: '/data' }
    host('redis-02.example.com') { host_port 8000, container_port: 6379; host_volume '/volumes/redis.8000', container_volume: '/data' }
    host('redis-02.example.com') { host_port 8001, container_port: 6379; host_volume '/volumes/redis.8001', container_volume: '/data' }
  end
````

Here's an example from our elasticsearch deploy, where we need to provide different node name and bind address to each container.

````ruby
 task :production => :common do
    set :tlsverify, true
    set_current_environment(:production)
    host_port 9200, container_port: 9200
    host_port 9300, container_port: 9300
    env_vars ES_HEAP_SIZE: '32g'
    host('es-01.example.com') { command ['/elasticsearch/bin/elasticsearch', "-Des.config=/elasticsearch/config/elasticsearch.yml", "--node.name=es-01", "--network.publish_host=10.0.0.1" }
    host('es-02.example.com') { command ['/elasticsearch/bin/elasticsearch', "-Des.config=/elasticsearch/config/elasticsearch.yml", "--node.name=es-02", "--network.publish_host=10.0.0.2" }
    host_volume '/volumes/elasticsearch', container_volume: '/data'
  end
````