### PR TITLE
Allow specifying Numerics in .megabytes, .gigabytes, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ For example, to limit the memory to 1G, and the cpu time slice to half the
 normal length, include the following:
 
 ```ruby
-memory 1024000000
+memory 1.gigabyte
 cpu_shares 512
 ```
 

--- a/lib/centurion.rb
+++ b/lib/centurion.rb
@@ -1,3 +1,7 @@
+Dir[File.join(File.dirname(__FILE__), 'core_ext', '*')].each do |file|
+  require file
+end
+
 Dir[File.join(File.dirname(__FILE__), 'centurion', '*')].each do |file|
   require file
 end

--- a/lib/core_ext/numeric_bytes.rb
+++ b/lib/core_ext/numeric_bytes.rb
@@ -1,0 +1,88 @@
+# Copied from ActiveSupport 4.2.1 lib/active_support/core_ext/numeric/bytes.rb
+# Original license follows
+
+# Copyright (c) 2005-2015 David Heinemeier Hansson
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+class Numeric
+  KILOBYTE = 1024
+  MEGABYTE = KILOBYTE * 1024
+  GIGABYTE = MEGABYTE * 1024
+  TERABYTE = GIGABYTE * 1024
+  PETABYTE = TERABYTE * 1024
+  EXABYTE  = PETABYTE * 1024
+
+  # Enables the use of byte calculations and declarations, like 45.bytes + 2.6.megabytes
+  #
+  #   2.bytes # => 2
+  def bytes
+    self
+  end
+  alias :byte :bytes
+
+  # Returns the number of bytes equivalent to the kilobytes provided.
+  #
+  #   2.kilobytes # => 2048
+  def kilobytes
+    self * KILOBYTE
+  end
+  alias :kilobyte :kilobytes
+
+  # Returns the number of bytes equivalent to the megabytes provided.
+  #
+  #   2.megabytes # => 2_097_152
+  def megabytes
+    self * MEGABYTE
+  end
+  alias :megabyte :megabytes
+
+  # Returns the number of bytes equivalent to the gigabytes provided.
+  #
+  #   2.gigabytes # => 2_147_483_648
+  def gigabytes
+    self * GIGABYTE
+  end
+  alias :gigabyte :gigabytes
+
+  # Returns the number of bytes equivalent to the terabytes provided.
+  #
+  #   2.terabytes # => 2_199_023_255_552
+  def terabytes
+    self * TERABYTE
+  end
+  alias :terabyte :terabytes
+
+  # Returns the number of bytes equivalent to the petabytes provided.
+  #
+  #   2.petabytes # => 2_251_799_813_685_248
+  def petabytes
+    self * PETABYTE
+  end
+  alias :petabyte :petabytes
+
+  # Returns the number of bytes equivalent to the exabytes provided.
+  #
+  #   2.exabytes # => 2_305_843_009_213_693_952
+  def exabytes
+    self * EXABYTE
+  end
+  alias :exabyte :exabytes
+end

--- a/lib/core_ext/numeric_bytes.rb
+++ b/lib/core_ext/numeric_bytes.rb
@@ -1,6 +1,10 @@
 # Copied from ActiveSupport 4.2.1 lib/active_support/core_ext/numeric/bytes.rb
-# Original license follows
-
+#
+# NOTE that THIS LICENSE ONLY APPLIES TO THIS FILE itself, not
+# to the rest of the project.
+#
+# ORIGINAL ACTIVE SUPPORT LICENSE FOLLOWS:
+#
 # Copyright (c) 2005-2015 David Heinemeier Hansson
 #
 # Permission is hereby granted, free of charge, to any person obtaining

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
-require 'centurion/deploy'
-require 'centurion/deploy_dsl'
-require 'centurion/logging'
+require 'centurion'
 
 describe Centurion::Deploy do
   let(:mock_ok_status)  { double('http_status_ok', status: 200) }
@@ -255,6 +253,12 @@ describe Centurion::Deploy do
         expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, "I like pie") }.to terminate.with_code(101)
         expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, -100) }.to terminate.with_code(101)
         expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, 0xFFFFFFFFFFFFFFFFFF) }.to terminate.with_code(101)
+      end
+
+      it 'still works when memory is specified in gigabytes' do
+        memory = 3.gigabytes
+        config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, cpu_shares)
+        expect(config['Memory']).to eq(3 * 1024 * 1024 * 1024)
       end
     end
   end


### PR DESCRIPTION
Under the hood, this change creates a new `lib/core_ext` structure for changing core class behaviors and brings in the bytes.rb file from ActiveSupport. Since only the one file was needed at this time it was simpler to just vendor the file rather than add a runtime dependency on ActiveSupport.

Old:
```
memory: 1000000000
```

New:
```
memory: 1.gigabyte
```