### PR TITLE
Prevent DOCKER_ environment variables from affecting our run

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -76,4 +76,5 @@ set :no_pull, opts[:no_pull_given]
 set :registry_user, opts[:registry_user] if opts[:registry_user]
 set :registry_password, opts[:registry_password] if opts[:registry_password]
 
+invoke('centurion:setup')
 invoke(opts[:action])

--- a/lib/tasks/centurion.rake
+++ b/lib/tasks/centurion.rake
@@ -1,0 +1,12 @@
+# The centurion:setup task is always run first to do any prework needed
+# to ensure a consistent and functioning environment
+
+namespace :centurion do
+  task :setup => [:clean_environment]
+
+  task :clean_environment do
+    ENV.delete('DOCKER_HOST')
+    ENV.delete('DOCKER_TLS_VERIFY')
+    ENV.delete('DOCKER_CERT_PATH')
+  end
+end


### PR DESCRIPTION
Because Centurion uses the HTTP API for some calls and the Docker CLI for others, it's behavior is inconsistent when DOCKER_* environment variables are present. These variables are picked up by the CLI automatically, but our HTTP code ignores them. To simplify behavior, this change removes those variables from Centurion's environment before any tasks are run.

