### PR TITLE
Address containers by their names instead of ports

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -16,10 +16,10 @@ module Centurion::Deploy
     end
   end
 
-  def wait_for_health_check_ok(health_check_method, target_server, port, endpoint, image_id, tag, sleep_time=5, retries=12)
+  def wait_for_health_check_ok(health_check_method, target_server, container_id, port, endpoint, image_id, tag, sleep_time=5, retries=12)
     info 'Waiting for the port to come up'
     1.upto(retries) do
-      if container_up?(target_server, port) && health_check_method.call(target_server, port, endpoint)
+      if container_up?(target_server, container_id) && health_check_method.call(target_server, port, endpoint)
         info 'Container is up!'
         break
       end
@@ -34,20 +34,13 @@ module Centurion::Deploy
     end
   end
 
-  def container_up?(target_server, port)
+  def container_up?(target_server, container_id)
     # The API returns a record set like this:
     #[{"Command"=>"script/run ", "Created"=>1394470428, "Id"=>"41a68bda6eb0a5bb78bbde19363e543f9c4f0e845a3eb130a6253972051bffb0", "Image"=>"quay.io/newrelic/rubicon:5f23ac3fad7979cd1efdc9295e0d8c5707d1c806", "Names"=>["/happy_pike"], "Ports"=>[{"IP"=>"0.0.0.0", "PrivatePort"=>80, "PublicPort"=>8484, "Type"=>"tcp"}], "Status"=>"Up 13 seconds"}]
 
-    running_containers = target_server.find_containers_by_public_port(port)
-    container = running_containers.pop
+    container = target_server.find_container_by_id(container_id)
 
-    unless running_containers.empty?
-      # This _should_ never happen, but...
-      error "More than one container is bound to port #{port} on #{target_server}!"
-      return false
-    end
-
-    if container && container['Ports'].any? { |bind| bind['PublicPort'].to_i == port.to_i }
+    if container
       info "Found container up for #{Time.now.to_i - container['Created'].to_i} seconds"
       return true
     end
@@ -76,11 +69,10 @@ module Centurion::Deploy
   end
 
   def cleanup_containers(target_server, service)
-    public_port = service.public_ports.first
-    old_containers = target_server.old_containers_for_port(public_port)
+    old_containers = target_server.old_containers_for_name(service.name)
     old_containers.shift(2)
 
-    info "Public port #{public_port}"
+    info "Service name #{service.name}"
     old_containers.each do |old_container|
       info "Removing old container #{old_container['Id'][0..7]} (#{old_container['Names'].join(',')})"
       target_server.remove_container(old_container['Id'])

--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -15,7 +15,7 @@ class Centurion::DockerServer
 
   def_delegators :docker_via_api, :create_container, :inspect_container,
                  :inspect_image, :ps, :start_container, :stop_container,
-                 :old_containers_for_port, :remove_container
+                 :remove_container
   def_delegators :docker_via_cli, :pull, :tail, :attach
 
   def initialize(host, docker_path, tls_params = {})
@@ -45,8 +45,18 @@ class Centurion::DockerServer
     ps.select do |container|
       next unless container && container['Names']
       container['Names'].find do |name|
-        name =~ /\A\/#{wanted_name}(-[a-f0-9]{7})?\Z/
+        name =~ /\A\/#{wanted_name}(-[a-f0-9]{14})?\Z/
       end
+    end
+  end
+
+  def find_container_by_id(container_id)
+    ps.find { |container| container && container['Id'] == container_id }
+  end
+
+  def old_containers_for_name(wanted_name)
+    find_containers_by_name(wanted_name).select do |container|
+      container["Status"] =~ /^(Exit |Exited)/
     end
   end
 

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -34,16 +34,6 @@ class Centurion::DockerViaApi
     JSON.load(response.body)
   end
 
-  def old_containers_for_port(host_port)
-    old_containers = ps(all: true).select do |container|
-      container["Status"] =~ /^(Exit |Exited)/
-    end.select do |container|
-      inspected = inspect_container container["Id"]
-      container_listening_on_port?(inspected, host_port)
-    end
-    old_containers
-  end
-
   def remove_container(container_id)
     path = "/v1.7/containers/#{container_id}"
     response = Excon.delete(

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -120,6 +120,7 @@ namespace :deploy do
         wait_for_health_check_ok(
           fetch(:health_check, method(:http_status_ok?)),
           server,
+          container['Id'],
           port,
           fetch(:status_endpoint, '/'),
           fetch(:rolling_deploy_wait_time, 5),

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -6,6 +6,7 @@ describe Centurion::Deploy do
   let(:mock_bad_status) { double('http_status_ok', status: 500) }
   let(:server)          { double('docker_server', attach: true, hostname: hostname) }
   let(:port)            { 8484 }
+  let(:container_id)    { '21adfd2ef2ef2349494a' }
   let(:container)       { { 'Ports' => [{ 'PublicPort' => port }, 'Created' => Time.now.to_i ], 'Id' => container_id, 'Names' => [ 'name1' ] } }
   let(:endpoint)        { '/status/check' }
   let(:container_id)    { '21adfd2ef2ef2349494a' }
@@ -51,23 +52,16 @@ describe Centurion::Deploy do
 
   describe '#container_up?' do
     it 'recognizes when no containers are running' do
-      expect(server).to receive(:find_containers_by_public_port).and_return([])
+      expect(server).to receive(:find_container_by_id).and_return(nil)
 
-      expect(test_deploy.container_up?(server, port)).to be_falsey
-    end
-
-    it 'complains when more than one container is bound to this port' do
-      expect(server).to receive(:find_containers_by_public_port).and_return([1,2])
-      expect(test_deploy).to receive(:error).with /More than one container/
-
-      expect(test_deploy.container_up?(server, port)).to be_falsey
+      expect(test_deploy.container_up?(server, container_id)).to be_falsey
     end
 
     it 'recognizes when the container is actually running' do
-      expect(server).to receive(:find_containers_by_public_port).and_return([container])
+      expect(server).to receive(:find_container_by_id).and_return(container)
       expect(test_deploy).to receive(:info).with /Found container/
 
-      expect(test_deploy.container_up?(server, port)).to be_truthy
+      expect(test_deploy.container_up?(server, container_id)).to be_truthy
     end
   end
 
@@ -80,7 +74,7 @@ describe Centurion::Deploy do
       allow(test_deploy).to receive(:container_up?).and_return(true)
       allow(test_deploy).to receive(:http_status_ok?).and_return(true)
 
-      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, port, '/foo', 'image_id', 'chaucer')
+      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, container_id, port, '/foo', 'image_id', 'chaucer')
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
       expect(test_deploy).to have_received(:info).with('Container is up!')
     end
@@ -92,7 +86,7 @@ describe Centurion::Deploy do
       expect(test_deploy).to receive(:exit)
       expect(test_deploy).to receive(:sleep).with(0)
 
-      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, port, '/foo', 'image_id', 'chaucer', 0, 1)
+      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, container_id, port, '/foo', 'image_id', 'chaucer', 0, 1)
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
     end
 
@@ -103,7 +97,7 @@ describe Centurion::Deploy do
       allow(test_deploy).to receive(:warn)
       expect(test_deploy).to receive(:exit)
 
-      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, port, '/foo', 'image_id', 'chaucer', 1, 0)
+      test_deploy.wait_for_health_check_ok(test_deploy.method(:http_status_ok?), server, container_id, port, '/foo', 'image_id', 'chaucer', 1, 0)
       expect(test_deploy).to have_received(:info).with(/Waiting for the port/)
     end
   end
@@ -111,13 +105,12 @@ describe Centurion::Deploy do
   describe '#cleanup_containers' do
     it 'deletes all but two containers' do
       service = Centurion::Service.new('walrus')
-      service.add_port_bindings(80, 8080)
-      expect(server).to receive(:old_containers_for_port).with(80).and_return([
-        {'Id' => '123', 'Names' => ['foo']},
-        {'Id' => '456', 'Names' => ['foo']},
-        {'Id' => '789', 'Names' => ['foo']},
-        {'Id' => '0ab', 'Names' => ['foo']},
-        {'Id' => 'cde', 'Names' => ['foo']},
+      expect(server).to receive(:old_containers_for_name).with('walrus').and_return([
+        {'Id' => '123', 'Names' => ['walrus-3bab311b460bdf']},
+        {'Id' => '456', 'Names' => ['walrus-4bab311b460bdf']},
+        {'Id' => '789', 'Names' => ['walrus-5bab311b460bdf']},
+        {'Id' => '0ab', 'Names' => ['walrus-6bab311b460bdf']},
+        {'Id' => 'cde', 'Names' => ['walrus-7bab311b460bdf']},
       ])
       expect(server).to receive(:remove_container).with('789')
       expect(server).to receive(:remove_container).with('0ab')

--- a/spec/docker_server_spec.rb
+++ b/spec/docker_server_spec.rb
@@ -11,7 +11,7 @@ describe Centurion::DockerServer do
        'Created' => 1414797234,
        'Id'      => '28970c706db0f69716af43527ed926acbd82581e1cef5e4e6ff152fce1b79972',
        'Image'   => 'centurion-test:latest',
-       'Names'   => ['/centurion-783aac4'],
+       'Names'   => ['/centurion-783aac48378283'],
        'Ports'   => [{'PrivatePort'=>80, 'Type'=>'tcp', 'IP'=>'0.0.0.0', 'PublicPort'=>23235}],
        'Status'  => 'Up 3 days'
      }
@@ -72,6 +72,21 @@ describe Centurion::DockerServer do
 
     it 'only returns correct matches by name' do
       expect(server.find_containers_by_name('fbomb')).to be_empty
+    end
+  end
+
+  context 'finding old containers' do
+    it 'finds stopped containers for the given service name' do
+      inspected_containers =
+        [
+            {"Id" => "123", "Names" => ["/centurion-1234567890abcd"], "Status" => "Exit 0"},
+            {"Id" => "456", "Names" => ["/centurion-2234567890abcd"], "Status" => "Running blah blah"},
+            {"Id" => "789", "Names" => ["/centurion-3234567890abcd"], "Status" => "Exited 1 mins ago"},
+            {"Id" => "918", "Names" => ["/fbomb-3234567890abcd"], "Status" => "Exited 1 mins ago"},
+        ]
+      allow(server).to receive(:ps).and_return(inspected_containers)
+
+      expect(server.old_containers_for_name('centurion').map { |c| c['Id'] }).to eq(["123", "789"])
     end
   end
 end


### PR DESCRIPTION
I've implemented the switch to address containers by their assigned names rather than by their port bindings. This paves the path for having multiple containers per host and it also allows to deploy containers that run in the host networking mode (there are no port mappings in this mode).