### PR TITLE
Introduce Centurion::Service

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -5,12 +5,9 @@ module Centurion; end
 
 module Centurion::Deploy
   FAILED_CONTAINER_VALIDATION = 100
-  INVALID_CGROUP_CPUSHARES_VALUE = 101
-  INVALID_CGROUP_MEMORY_VALUE = 102
 
-  def stop_containers(target_server, port_bindings, timeout = 30)
-    public_port    = public_port_for(port_bindings)
-    old_containers = target_server.find_containers_by_public_port(public_port)
+  def stop_containers(target_server, service, timeout = 30)
+    old_containers = target_server.find_containers_by_public_port(service.public_ports.first)
     info "Stopping container(s): #{old_containers.inspect}"
 
     old_containers.each do |old_container|
@@ -74,23 +71,12 @@ module Centurion::Deploy
     false
   end
 
-  def is_a_uint64?(value)
-    result = false
-    if !value.is_a? Integer
-      return result
-    end
-    if value < 0 || value > 0xFFFFFFFFFFFFFFFF
-      return result
-    end
-    return true
-  end
-
   def wait_for_load_balancer_check_interval
     sleep(fetch(:rolling_deploy_check_interval, 5))
   end
 
-  def cleanup_containers(target_server, port_bindings)
-    public_port    = public_port_for(port_bindings)
+  def cleanup_containers(target_server, service)
+    public_port = service.public_ports.first
     old_containers = target_server.old_containers_for_port(public_port)
     old_containers.shift(2)
 
@@ -101,122 +87,33 @@ module Centurion::Deploy
     end
   end
 
-  def container_config_for(target_server, image_id, port_bindings=nil, env_vars=nil, volumes=nil, command=nil, memory=nil, cpu_shares=nil)
-
-    if memory && ! is_a_uint64?(memory)
-      error "Invalid value for CGroup memory constraint: #{memory}, value must be a between 0 and 18446744073709551615"
-      exit(INVALID_CGROUP_MEMORY_VALUE)
-    end
-
-    if cpu_shares && ! is_a_uint64?(cpu_shares)
-      error "Invalid value for CGroup CPU constraint: #{cpu_shares}, value must be between 0 and 18446744073709551615"
-      exit(INVALID_CGROUP_CPUSHARES_VALUE)
-    end
-
-    container_config = {
-      'Image'        => image_id,
-      'Hostname'     => fetch(:container_hostname, target_server.hostname),
-    }
-
-    container_config.merge!('Cmd' => command) if command
-    container_config.merge!('Memory' => memory) if memory
-    container_config.merge!('CpuShares' => cpu_shares) if cpu_shares
-
-    if port_bindings
-      container_config['ExposedPorts'] ||= {}
-      port_bindings.keys.each do |port|
-        container_config['ExposedPorts'][port] = {}
-      end
-    end
-
-    if env_vars
-      container_config['Env'] = env_vars.map do |k,v|
-        "#{k}=#{interpolate_var(v, target_server)}"
-      end
-    end
-
-    if volumes
-      container_config['Volumes'] = volumes.inject({}) do |memo, v|
-        memo[v.split(/:/).last] = {}
-        memo
-      end
-      container_config['VolumesFrom'] = 'parent'
-    end
-
-    container_config
-  end
-
-  def start_new_container(target_server, image_id, port_bindings, volumes, env_vars=nil, command=nil, memory=nil, cpu_shares=nil)
-    container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, command, memory, cpu_shares)
-    start_container_with_config(target_server, volumes, port_bindings, container_config)
-  end
-
-  def launch_console(target_server, image_id, port_bindings, volumes, env_vars=nil)
-    container_config = container_config_for(target_server, image_id, port_bindings, env_vars, volumes, ['/bin/bash']).merge(
-      'AttachStdin' => true,
-      'Tty'         => true,
-      'OpenStdin'   => true,
-    )
-
-    container = start_container_with_config(target_server, volumes, port_bindings, container_config)
-
-    target_server.attach(container['Id'])
-  end
-
-  private
-
-  # By default we always use on-failure policy.
-  def build_host_config_restart_policy(host_config={})
-    host_config['RestartPolicy'] = {}
-
-    restart_policy_name = fetch(:restart_policy_name) || 'on-failure'
-    restart_policy_name = 'on-failure' unless ["always", "on-failure", "no"].include?(restart_policy_name)
-
-    restart_policy_max_retry_count = fetch(:restart_policy_max_retry_count) || 10
-
-    host_config['RestartPolicy']['Name'] = restart_policy_name
-    host_config['RestartPolicy']['MaximumRetryCount'] = restart_policy_max_retry_count if restart_policy_name == 'on-failure'
-
-    host_config
-  end
-
-  def start_container_with_config(target_server, volumes, port_bindings, container_config)
+  def start_new_container(server, service, restart_policy)
+    container_config = service.build_config(server.hostname)
     info "Creating new container for #{container_config['Image'][0..7]}"
-    new_container = target_server.create_container(container_config, fetch(:name))
+    container = server.create_container(container_config, service.name)
 
-    host_config = {}
+    host_config = service.build_host_config(restart_policy)
 
-    # Map some host volumes if needed
-    host_config['Binds'] = volumes if volumes && !volumes.empty?
+    info "Starting new container #{container['Id'][0..7]}"
+    server.start_container(container['Id'], host_config)
 
-    # Bind the ports
-    host_config['PortBindings'] = port_bindings
+    info "Inspecting new container #{container['Id'][0..7]}:"
+    info server.inspect_container(container['Id'])
 
-    # DNS if specified
-    dns = fetch(:custom_dns)
-    host_config['Dns'] = dns if dns
-
-    # Restart Policy
-    host_config = build_host_config_restart_policy(host_config)
-
-    info "Starting new container #{new_container['Id'][0..7]}"
-    target_server.start_container(new_container['Id'], host_config)
-
-    info "Inspecting new container #{new_container['Id'][0..7]}:"
-    info target_server.inspect_container(new_container['Id'])
-
-    new_container
+    container
   end
 
-  def interpolate_var(val, target_server)
-    val.gsub('%DOCKER_HOSTNAME%', target_server.hostname)
-      .gsub('%DOCKER_HOST_IP%', host_ip(target_server.hostname))
-  end
+  def launch_console(server, service)
+    container_config = service.build_console_config(server.hostname)
+    info "Creating new container for #{container_config['Image'][0..7]}"
 
-  def host_ip(hostname)
-    @host_ip ||= {}
-    return @host_ip[hostname] if @host_ip.has_key?(hostname)
-    @host_ip[hostname] = Socket.getaddrinfo(hostname, nil).first[2]
-  end
+    container = server.create_container(container_config, service.name)
 
+    host_config = service.build_host_config
+
+    info "Starting new container #{container['Id'][0..7]}"
+    server.start_container(container['Id'], host_config)
+
+    server.attach(container['Id'])
+  end
 end

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -1,4 +1,5 @@
 require_relative 'docker_server_group'
+require_relative 'docker_server'
 require 'uri'
 
 module Centurion::DeployDSL
@@ -7,11 +8,7 @@ module Centurion::DeployDSL
   end
 
   def env_vars(new_vars)
-    current = fetch(:env_vars, {})
-    new_vars.each_pair do |new_key, new_value|
-      current[new_key.to_s] = new_value.to_s
-    end
-    set(:env_vars, current)
+    service_under_construction.add_env_vars(new_vars)
   end
 
   def host(hostname)
@@ -21,15 +18,15 @@ module Centurion::DeployDSL
   end
 
   def memory(memory)
-    set(:memory, memory)
+    service_under_construction.memory = memory
   end
 
   def cpu_shares(cpu_shares)
-    set(:cpu_shares, cpu_shares)
+    service_under_construction.cpu_shares = cpu_shares
   end
 
   def command(command)
-    set(:command, command)
+    service_under_construction.command = command
   end
 
   def localhost
@@ -43,29 +40,16 @@ module Centurion::DeployDSL
     validate_options_keys(options, [ :host_ip, :container_port, :type ])
     require_options_keys(options,  [ :container_port ])
 
-    add_to_bindings(
-      options[:host_ip],
-      options[:container_port],
-      port,
-      options[:type] || 'tcp'
-    )
-  end
-
-  def public_port_for(port_bindings)
-    # {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]}
-    first_port_binding = port_bindings.values.first
-    first_port_binding.first['HostPort']
+    service_under_construction.add_port_bindings(port, options[:container_port], options[:type] || 'tcp', options[:host_ip])
   end
 
   def host_volume(volume, options)
     validate_options_keys(options, [ :container_volume ])
     require_options_keys(options,  [ :container_volume ])
 
-    binds            = fetch(:binds, [])
     container_volume = options[:container_volume]
 
-    binds << "#{volume}:#{container_volume}"
-    set(:binds, binds)
+    service_under_construction.add_volume(volume, container_volume)
   end
 
   def get_current_tags_for(image)
@@ -85,21 +69,36 @@ module Centurion::DeployDSL
    set(:health_check, method)
   end
 
+  def defined_service
+    service = fetch(:service, {})
+    service.image = fetch(:image)
+    service.hostname = fetch(:container_hostname)
+    service.dns = fetch(:custom_dns)
+    service
+  end
+
+  def defined_health_check
+    Centurion::HealthCheck.new(fetch(:health_check, method(:http_status_ok?)),
+                               fetch(:status_endpoint, '/'),
+                               fetch(:rolling_deploy_wait_time, 5),
+                               fetch(:rolling_deploy_retries, 24))
+  end
+
+  def defined_restart_policy
+    Centurion::Service::RestartPolicy.new(fetch(:restart_policy_name, 'on-failure'), fetch(:restart_policy_max_retry_count, 10))
+  end
+
   private
+
+  def service_under_construction
+    service = fetch(:service, Centurion::Service.new(fetch(:project)))
+    set(:service, service)
+  end
+
 
   def build_server_group
     hosts, docker_path = fetch(:hosts, []), fetch(:docker_path)
     Centurion::DockerServerGroup.new(hosts, docker_path, build_tls_params)
-  end
-
-  def add_to_bindings(host_ip, container_port, port, type='tcp')
-    set(:port_bindings, fetch(:port_bindings, {}).tap do |bindings|
-      binding = { 'HostPort' => port.to_s }.tap do |b|
-        b['HostIp'] = host_ip if host_ip
-      end
-      bindings["#{container_port.to_s}/#{type}"] = [ binding ]
-      bindings
-    end)
   end
 
   def validate_options_keys(options, valid_keys)

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -1,0 +1,164 @@
+module Centurion
+  class Service
+    def initialize(name)
+      @name = name
+      @env_vars = {}
+      @volumes = []
+      @port_bindings = []
+    end
+
+    attr_accessor :command, :dns, :image, :hostname, :name
+    attr_reader :memory, :cpu_shares, :env_vars, :volumes, :port_bindings
+
+    def add_env_vars(new_vars)
+      @env_vars.merge!(new_vars)
+    end
+
+    def add_port_bindings(host_port, container_port, type = 'tcp', host_ip = nil)
+      @port_bindings << PortBinding.new(host_port, container_port, type, host_ip)
+    end
+
+    def add_volume(host_volume, container_volume)
+      @volumes << Volume.new(host_volume, container_volume)
+    end
+
+    def memory=(bytes)
+      if !bytes || !is_a_uint64?(bytes)
+    raise ArgumentError, "invalid value for cgroup memory constraint: #{bytes}, value must be a between 0 and 18446744073709551615"
+      end
+      @memory = bytes
+    end
+
+    def cpu_shares=(shares)
+      if !shares || !is_a_uint64?(shares)
+        raise ArgumentError, "invalid value for cgroup CPU constraint: #{shares}, value must be a between 0 and 18446744073709551615"
+      end
+      @cpu_shares = shares
+    end
+
+    def image=(image)
+      @image = image
+    end
+
+    def build_config(server_hostname)
+      container_config = {
+          'Image'        => image,
+          'Hostname'     => hostname || server_hostname,
+      }
+
+      container_config['Cmd'] = command if command
+      container_config['Memory'] = memory if memory
+      container_config['CpuShares'] = cpu_shares if cpu_shares
+
+      unless port_bindings.empty?
+        container_config['ExposedPorts'] = port_bindings.reduce({}) do |config, binding|
+          config["#{binding.container_port}/#{binding.type}"] = {}
+          config
+        end
+      end
+
+      unless env_vars.empty?
+        container_config['Env'] = env_vars.map do |k,v|
+          "#{k}=#{interpolate_var(v, server_hostname)}"
+        end
+      end
+
+      unless volumes.empty?
+        container_config['Volumes'] = volumes.inject({}) do |memo, v|
+          memo[v.container_volume] = {}
+          memo
+        end
+        container_config['VolumesFrom'] = 'parent'
+      end
+
+      container_config
+    end
+
+    def build_host_config(restart_policy = nil)
+      host_config = {}
+
+      # Map some host volumes if needed
+      host_config['Binds'] = volume_binds_config if volume_binds_config
+
+      # Bind the ports
+      host_config['PortBindings'] = port_bindings_config
+
+      # DNS if specified
+      host_config['Dns'] = dns if dns
+
+      # Restart Policy
+      if restart_policy
+        host_config['RestartPolicy'] = {}
+
+        restart_policy_name = restart_policy.name
+        restart_policy_name = 'on-failure' unless ["always", "on-failure", "no"].include?(restart_policy_name)
+
+        host_config['RestartPolicy']['Name'] = restart_policy_name
+        host_config['RestartPolicy']['MaximumRetryCount'] = restart_policy.max_retry_count || 10 if restart_policy_name == 'on-failure'
+      end
+
+      host_config
+    end
+
+    def build_console_config(hostname)
+      config = build_config(hostname)
+      config.merge({
+        'Cmd' => ['/bin/bash'],
+        'AttachStdin' => true,
+        'Tty'         => true,
+        'OpenStdin'   => true,
+      })
+    end
+
+    def volume_binds_config
+      @volumes.map { |volume| "#{volume.host_volume}:#{volume.container_volume}" }
+    end
+
+    def port_bindings_config
+      @port_bindings.inject({}) do |memo, binding|
+        config = {}
+        config['HostPort'] = binding.host_port.to_s
+        config['HostIp'] = binding.host_ip if binding.host_ip
+        memo["#{binding.container_port}/#{binding.type}"] = [config]
+        memo
+      end
+    end
+
+    def public_ports
+      @port_bindings.map(&:host_port)
+    end
+
+    private
+
+    def is_a_uint64?(value)
+      result = false
+      if !value.is_a? Integer
+        return result
+      end
+      if value < 0 || value > 0xFFFFFFFFFFFFFFFF
+        return result
+      end
+      return true
+    end
+
+    def interpolate_var(val, hostname)
+      val.gsub('%DOCKER_HOSTNAME%', hostname)
+        .gsub('%DOCKER_HOST_IP%', host_ip(hostname))
+    end
+
+    def host_ip(hostname)
+      @host_ip ||= {}
+      return @host_ip[hostname] if @host_ip.has_key?(hostname)
+      @host_ip[hostname] = Socket.getaddrinfo(hostname, nil).first[2]
+    end
+
+    class RestartPolicy < Struct.new(:name, :max_retry_count)
+    end
+
+    class Volume < Struct.new(:host_volume, :container_volume)
+    end
+
+    class PortBinding < Struct.new(:host_port, :container_port, :type, :host_ip)
+    end
+  end
+end

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -6,8 +6,9 @@ describe Centurion::Deploy do
   let(:mock_bad_status) { double('http_status_ok', status: 500) }
   let(:server)          { double('docker_server', attach: true, hostname: hostname) }
   let(:port)            { 8484 }
-  let(:container)       { { 'Ports' => [{ 'PublicPort' => port }, 'Created' => Time.now.to_i ], 'Id' => '21adfd2ef2ef2349494a', 'Names' => [ 'name1' ] } }
+  let(:container)       { { 'Ports' => [{ 'PublicPort' => port }, 'Created' => Time.now.to_i ], 'Id' => container_id, 'Names' => [ 'name1' ] } }
   let(:endpoint)        { '/status/check' }
+  let(:container_id)    { '21adfd2ef2ef2349494a' }
   let(:test_deploy) do
     Object.new.tap do |o|
       o.send(:extend, Centurion::Deploy)
@@ -109,7 +110,9 @@ describe Centurion::Deploy do
 
   describe '#cleanup_containers' do
     it 'deletes all but two containers' do
-      expect(server).to receive(:old_containers_for_port).with(port.to_s).and_return([
+      service = Centurion::Service.new('walrus')
+      service.add_port_bindings(80, 8080)
+      expect(server).to receive(:old_containers_for_port).with(80).and_return([
         {'Id' => '123', 'Names' => ['foo']},
         {'Id' => '456', 'Names' => ['foo']},
         {'Id' => '789', 'Names' => ['foo']},
@@ -120,22 +123,23 @@ describe Centurion::Deploy do
       expect(server).to receive(:remove_container).with('0ab')
       expect(server).to receive(:remove_container).with('cde')
 
-      test_deploy.cleanup_containers(server, {'80/tcp' => [{'HostIp' => '0.0.0.0', 'HostPort' => port.to_s}]})
+      test_deploy.cleanup_containers(server, service)
     end
   end
 
   describe '#stop_containers' do
     it 'calls stop_container on the right containers' do
+      service = Centurion::Service.new(:centurion)
+      service.add_port_bindings(80, 80)
+
       second_container = container.dup
       containers = [ container, second_container ]
-      bindings = {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]}
 
-      expect(server).to receive(:find_containers_by_public_port).and_return(containers)
-      expect(test_deploy).to receive(:public_port_for).with(bindings).and_return('80')
+      expect(server).to receive(:find_containers_by_public_port).with(80).and_return(containers)
       expect(server).to receive(:stop_container).with(container['Id'], 30).once
       expect(server).to receive(:stop_container).with(second_container['Id'], 30).once
 
-      test_deploy.stop_containers(server, bindings)
+      test_deploy.stop_containers(server, service)
     end
   end
 
@@ -149,348 +153,35 @@ describe Centurion::Deploy do
     end
   end
 
-  describe '#container_config_for' do
-    let(:image_id) { 'image_id' }
-    let(:port_bindings) { nil }
-    let(:env) { nil }
-    let(:volumes) { nil }
-    let(:command) { nil }
-
-    it 'works without env_vars, port_bindings, or a command' do
-      config = test_deploy.container_config_for(server, image_id)
-
-      expect(config).to be_a(Hash)
-      expect(config.keys).to match_array(%w{ Hostname Image })
-    end
-
-    context 'when port bindings are specified' do
-      let(:port_bindings) { {1234 => 80, 9876 => 80} }
-
-      it 'sets the ExposedPorts key in the config correctly' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings)
-
-        expect(config['ExposedPorts']).to be_a(Hash)
-        expect(config['ExposedPorts'].keys).to eq port_bindings.keys
-      end
-    end
-
-    context 'when env vars are specified' do
-      let(:env) { {
-        'FOO' => 'BAR',
-        'BAZ' => '%DOCKER_HOSTNAME%.example.com',
-        'BAR' => '%DOCKER_HOST_IP%:1234'
-      } }
-
-      it 'sets the Env key in the config' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env)
-
-        expect(config).to be_a(Hash)
-        expect(config.keys).to match_array(%w{ Hostname Image Env })
-        expect(config['Env']).to include('FOO=BAR')
-      end
-
-      it 'interpolates the hostname into env_vars' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env)
-
-        expect(config['Env']).to include('BAZ=host1.example.com')
-      end
-
-      it 'interpolates the host IP into the env_vars' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env)
-
-        expect(config['Env']).to include('BAR=172.16.0.1:1234')
-      end
-    end
-
-    context 'when volumes are specified' do
-      let(:volumes) { ["/tmp/foo:/tmp/chaucer"] }
-
-      it 'sets the Volumes key in the config' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes)
-
-        expect(config).to be_a(Hash)
-        expect(config.keys).to match_array(%w{ Hostname Image Volumes VolumesFrom })
-        expect(config['Volumes']['/tmp/chaucer']).to eq({})
-      end
-    end
-
-    context 'when a custom command is specified' do
-      let(:command) { ['/bin/echo', 'hi'] }
-
-      it 'sets the Cmd key in the config' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command)
-
-        expect(config).to be_a(Hash)
-        expect(config.keys).to match_array(%w{ Hostname Image Cmd })
-        expect(config['Cmd']).to eq(command)
-      end
-    end
-
-    context 'when cgroup limits are specified' do
-      let(:memory) { 10000000 }
-      let(:cpu_shares) { 1234 }
-
-      before do
-        allow(test_deploy).to receive(:error) # Make sure we don't have red output in tests
-      end
-
-      it 'sets cgroup limits in the config' do
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, cpu_shares)
-
-        expect(config).to be_a(Hash)
-        expect(config.keys).to match_array(%w{ Hostname Image Memory CpuShares })
-        expect(config['Memory']).to eq(10000000)
-        expect(config['CpuShares']).to eq(1234)
-      end
-
-      it 'throws a fatal error value for Cgroup Memory limit is invalid' do
-        expect { config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, "I like pie", cpu_shares) }.to terminate.with_code(102)
-        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, -100, cpu_shares) }.to terminate.with_code(102)
-        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, 0xFFFFFFFFFFFFFFFFFF, cpu_shares) }.to terminate.with_code(102)
-      end
-
-      it 'throws a fatal error value for Cgroup CPU limit is invalid' do
-        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, "I like pie") }.to terminate.with_code(101)
-        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, -100) }.to terminate.with_code(101)
-        expect { test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, 0xFFFFFFFFFFFFFFFFFF) }.to terminate.with_code(101)
-      end
-
-      it 'still works when memory is specified in gigabytes' do
-        memory = 3.gigabytes
-        config = test_deploy.container_config_for(server, image_id, port_bindings, env, volumes, command, memory, cpu_shares)
-        expect(config['Memory']).to eq(3 * 1024 * 1024 * 1024)
-      end
-    end
-  end
-
-  describe '#start_container_with_config' do
-    let(:bindings) { {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]} }
-
-    it 'pass host_config to start_container' do
-      allow(server).to receive(:container_config_for).and_return({
-        'Image'        => 'image_id',
-        'Hostname'     => server.hostname,
-      })
-
-      allow(server).to receive(:create_container).and_return({
-        'Id' => 'abc123456'
-      })
-
-      allow(server).to receive(:inspect_container)
-
-      allow(test_deploy).to receive(:fetch).with(:custom_dns).and_return('8.8.8.8')
-      allow(test_deploy).to receive(:fetch).with(:name).and_return(nil)
-
-      expect(server).to receive(:start_container).with(
-        'abc123456',
-        {
-          'PortBindings' => bindings,
-          'Dns' => '8.8.8.8',
-          'RestartPolicy' => {
-            'Name' => 'on-failure',
-            'MaximumRetryCount' => 10
-          }
-        }
-      ).once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
-    end
-  end
-
-  describe '#start_container_with_restart_policy' do
-    let(:bindings) { {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]} }
-
-    before do
-      allow(server).to receive(:container_config_for).and_return({
-        'Image'        => 'image_id',
-        'Hostname'     => server.hostname,
-      })
-
-      allow(server).to receive(:create_container).and_return({
-        'Id' => 'abc123456'
-      })
-
-      allow(server).to receive(:inspect_container)
-    end
-
-    it 'pass no restart policy to start_container' do
-      expect(server).to receive(:start_container).with(
-        'abc123456',
-        {
-          'PortBindings' => bindings,
-          'RestartPolicy' => {
-            'Name' => 'on-failure',
-            'MaximumRetryCount' => 10
-          }
-        }
-      ).once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
-    end
-
-    it 'pass "always" restart policy to start_container' do
-      allow(test_deploy).to receive(:fetch).with(:restart_policy_name).and_return('always')
-
-      expect(server).to receive(:start_container).with(
-        'abc123456',
-        {
-          'PortBindings' => bindings,
-          'RestartPolicy' => {
-            'Name' => 'always'
-          }
-        }
-      ).once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
-    end
-
-    it 'pass "on-failure with 50 retries" restart policy to start_container' do
-      allow(test_deploy).to receive(:fetch).with(:restart_policy_name).and_return('on-failure')
-      allow(test_deploy).to receive(:fetch).with(:restart_policy_max_retry_count).and_return(50)
-
-      expect(server).to receive(:start_container).with(
-        'abc123456',
-        {
-          'PortBindings' => bindings,
-          'RestartPolicy' => {
-            'Name' => 'on-failure',
-            'MaximumRetryCount' => 50
-          }
-        }
-      ).once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
-    end
-
-    it 'pass "no" restart policy to start_container' do
-      allow(test_deploy).to receive(:fetch).with(:restart_policy_name).and_return('no')
-
-      expect(server).to receive(:start_container).with(
-        'abc123456',
-        {
-          'PortBindings' => bindings,
-          'RestartPolicy' => {
-            'Name' => 'no'
-          }
-        }
-      ).once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
-    end
-
-    it 'pass "garbage" restart policy to start_container' do
-      allow(test_deploy).to receive(:fetch).with(:restart_policy_name).and_return('garbage')
-
-      expect(server).to receive(:start_container).with(
-        'abc123456',
-        {
-          'PortBindings' => bindings,
-          'RestartPolicy' => {
-            'Name' => 'on-failure',
-            'MaximumRetryCount' => 10
-          }
-        }
-      ).once
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil, nil)
-    end
-  end
-
   describe '#start_new_container' do
     let(:bindings) { {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]} }
     let(:env)      { { 'FOO' => 'BAR' } }
     let(:volumes)  { ['/foo:/bar'] }
     let(:command)  { ['/bin/echo', 'hi'] }
 
-    it 'configures the container' do
-      expect(test_deploy).to receive(:container_config_for).with(server, 'image_id', bindings, nil, {}, nil, nil, nil).once
-
-      allow(test_deploy).to receive(:start_container_with_config)
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {}, nil)
-    end
-
-    it 'starts the container' do
-      expect(test_deploy).to receive(:start_container_with_config).with(server, {}, anything(), anything())
-
-      test_deploy.start_new_container(server, 'image_id', bindings, {})
-    end
-
-    it 'sets the container hostname when asked' do
-      allow(test_deploy).to receive(:fetch).with(:container_hostname, anything()).and_return('chaucer')
-
-      expect(server).to receive(:create_container).with(
-        hash_including(
-          'Image'        => 'image_id',
-          'Hostname'     => 'chaucer',
-          'ExposedPorts' => {'80/tcp'=>{}},
-          'Cmd'          => command,
-          'Env'          => ['FOO=BAR'],
-          'Volumes'      => {'/bar' => {}},
-        ),
-        nil
-      ).and_return(container)
-
-      expect(server).to receive(:start_container)
-      expect(server).to receive(:inspect_container)
-      test_deploy.start_new_container(server, 'image_id', bindings, volumes, env, command)
-    end
-
     it 'ultimately asks the server object to do the work' do
-      allow(test_deploy).to receive(:fetch).with(:custom_dns).and_return(nil)
-      allow(test_deploy).to receive(:fetch).with(:name).and_return('app1')
+      service = double(:Service, name: :centurion, build_config: {"Image" => "abcdef"}, build_host_config: {})
+      restart_policy = double(:RestartPolicy)
 
-      expect(server).to receive(:create_container).with(
-        hash_including(
-          'Image'        => 'image_id',
-          'Hostname'     => hostname,
-          'ExposedPorts' => {'80/tcp'=>{}},
-          'Cmd'          => command,
-          'Env'          => ['FOO=BAR'],
-          'Volumes'      => {'/bar' => {}},
-        ),
-        'app1'
-      ).and_return(container)
+      expect(server).to receive(:create_container).with({"Image" => "abcdef"}, :centurion).and_return(container)
 
       expect(server).to receive(:start_container)
       expect(server).to receive(:inspect_container)
 
-      new_container = test_deploy.start_new_container(server, 'image_id', bindings, volumes, env, command)
+      new_container = test_deploy.start_new_container(server, service, restart_policy)
       expect(new_container).to eq(container)
     end
   end
 
   describe '#launch_console' do
-    let(:bindings)   { {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]} }
-    let(:volumes)    { nil }
-    let(:env)        { nil }
-    let(:command)    { nil }
-    let(:memory)     { nil }
-    let(:cpu_shares) { nil }
-
-    it 'configures the container' do
-      expect(test_deploy).to receive(:container_config_for).with(server, 'image_id', bindings, env, volumes, command, memory, cpu_shares).once
-      allow(test_deploy).to receive(:start_container_with_config)
-
-      test_deploy.start_new_container(server, 'image_id', bindings, volumes, env, command, memory, cpu_shares)
-    end
-
-    it 'augments the container_config' do
-      expect(test_deploy).to receive(:start_container_with_config).with(server, volumes,
-        anything(),
-        hash_including('Cmd' => [ '/bin/bash' ], 'AttachStdin' => true , 'Tty' => true , 'OpenStdin' => true)
-      ).and_return({'Id' => 'shakespeare'})
-
-      test_deploy.launch_console(server, 'image_id', bindings, volumes, env)
-    end
-
     it 'starts the console' do
-      expect(test_deploy).to receive(:start_container_with_config).with(
-        server, nil, anything(), anything()
-      ).and_return({'Id' => 'shakespeare'})
+      service = double(:Service, name: :centurion, build_console_config: {"Image" => "abcdef"}, build_host_config: {})
 
-      test_deploy.launch_console(server, 'image_id', bindings, volumes, env)
-      expect(server).to have_received(:attach).with('shakespeare')
+      expect(server).to receive(:create_container).with({"Image" => "abcdef"}, :centurion).and_return(container)
+      expect(server).to receive(:start_container)
+
+      test_deploy.launch_console(server, service)
+      expect(server).to have_received(:attach).with(container_id)
     end
   end
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -1,0 +1,198 @@
+require 'spec_helper'
+require 'centurion/service'
+
+describe Centurion::Service do
+  let(:service) { Centurion::Service.new(:redis) }
+
+  it 'has an associated hostname' do
+    service.hostname = 'example.com'
+    expect(service.hostname).to eq('example.com')
+  end
+
+  it 'starts with a command' do
+    service.command = ['redis-server']
+    expect(service.command).to eq(['redis-server'])
+  end
+
+  it 'has memory bounds' do
+    service.memory = 1024
+    expect(service.memory).to eq(1024)
+  end
+
+  it 'rejects non-numeric memory bounds' do
+    expect(-> { service.memory = 'all' }).to raise_error
+  end
+
+  it 'has cpu shares bounds' do
+    service.cpu_shares = 512
+    expect(service.cpu_shares).to eq(512)
+  end
+
+  it 'rejects non-numeric cpu shares' do
+    expect(-> { service.cpu_shares = 'all' }).to raise_error
+  end
+
+  it 'has a custom dns association' do
+    service.dns = 'redis.example.com'
+    expect(service.dns).to eq('redis.example.com')
+  end
+
+  it 'boots from a docker image' do
+    service.image = 'registry.hub.docker.com/library/redis'
+    expect(service.image).to eq('registry.hub.docker.com/library/redis')
+  end
+
+  it 'has env vars' do
+    service.add_env_vars(SLAVE_OF: '127.0.0.1')
+    service.add_env_vars(USE_AOF: '1')
+    expect(service.env_vars).to eq(SLAVE_OF: '127.0.0.1', USE_AOF: '1')
+  end
+
+  it 'has volume bindings' do
+    service.add_volume('/volumes/redis/data', '/data')
+    service.add_volume('/volumes/redis/config', '/config')
+    expect(service.volumes).to eq([Centurion::Service::Volume.new('/volumes/redis/data', '/data'),
+                                   Centurion::Service::Volume.new('/volumes/redis/config', '/config')])
+  end
+
+  it 'has port mappings' do
+    service.add_port_bindings(8000, 6379, 'tcp', '127.0.0.1')
+    service.add_port_bindings(18000, 16379, 'tcp', '127.0.0.1')
+    expect(service.port_bindings).to eq([Centurion::Service::PortBinding.new(8000, 6379, 'tcp', '127.0.0.1'),
+                                         Centurion::Service::PortBinding.new(18000, 16379, 'tcp', '127.0.0.1')])
+  end
+
+  it 'builds a list of public ports for the service' do
+    service.add_port_bindings(8000, 6379, 'tcp', '127.0.0.1')
+    service.add_port_bindings(18000, 16379, 'tcp', '127.0.0.1')
+    expect(service.public_ports).to eq([8000, 18000])
+  end
+
+  it 'builds a valid docker container configuration' do
+    service = Centurion::Service.new(:redis)
+    service.image = 'http://registry.hub.docker.com/library/redis'
+    service.command = ['redis-server', '--appendonly', 'yes']
+    service.memory = 1024
+    service.cpu_shares = 512
+    service.add_env_vars(SLAVE_OF: '127.0.0.2')
+    service.add_port_bindings(8000, 6379, 'tcp', '10.0.0.1')
+    service.add_volume('/volumes/redis.8000', '/data')
+
+    expect(service.build_config('example.com')).to eq({
+      'Image' => 'http://registry.hub.docker.com/library/redis',
+      'Hostname' => 'example.com',
+      'Cmd' => ['redis-server', '--appendonly', 'yes'],
+      'Memory' => 1024,
+      'CpuShares' => 512,
+      'ExposedPorts' => {'6379/tcp' => {}},
+      'Env' => ['SLAVE_OF=127.0.0.2'],
+      'Volumes' => {'/data' => {}},
+      'VolumesFrom' => 'parent'
+    })
+  end
+
+  it 'interpolates hostname into env variables' do
+    allow(Socket).to receive(:getaddrinfo).and_return([["AF_INET", 0, "93.184.216.34", "93.184.216.34", 2, 1, 6]])
+    service = Centurion::Service.new(:redis)
+    service.add_env_vars(HOST: '%DOCKER_HOSTNAME%')
+
+    expect(service.build_config('example.com')['Env']).to eq(['HOST=example.com'])
+  end
+
+  it 'interpolates host ip into env variables' do
+    allow(Socket).to receive(:getaddrinfo).and_return([["AF_INET", 0, "93.184.216.34", "93.184.216.34", 2, 1, 6]])
+    service = Centurion::Service.new(:redis)
+    service.add_env_vars(HOST: '%DOCKER_HOST_IP%')
+
+    expect(service.build_config('example.com')['Env']).to eq(['HOST=93.184.216.34'])
+  end
+
+  it 'builds a valid docker host configuration' do
+    service = Centurion::Service.new(:redis)
+    service.dns = 'example.com'
+    service.add_port_bindings(8000, 6379)
+    service.add_volume('/volumes/redis.8000', '/data')
+
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('on-failure', 10))).to eq({
+      'Binds' => ['/volumes/redis.8000:/data'],
+      'PortBindings' => {
+        '6379/tcp' => [{'HostPort' => '8000'}]
+      },
+      'Dns' => 'example.com',
+      'RestartPolicy' => {
+        'Name' => 'on-failure',
+        'MaximumRetryCount' => 10
+      }
+    })
+  end
+
+  it 'ignores garbage restart policy' do
+    service = Centurion::Service.new(:redis)
+
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('garbage'))).to eq({
+       'Binds' => [],
+       'PortBindings' => {},
+       'RestartPolicy' => {
+         'Name' => 'on-failure',
+         'MaximumRetryCount' => 10
+       }
+     })
+  end
+
+  it 'accepts "no" restart policy' do
+    service = Centurion::Service.new(:redis)
+
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('no'))).to eq({
+      'Binds' => [],
+      'PortBindings' => {},
+       'RestartPolicy' => {
+         'Name' => 'no',
+       }
+     })
+  end
+
+  it 'accepts "always" restart policy' do
+    service = Centurion::Service.new(:redis)
+
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('always'))).to eq({
+      'Binds' => [],
+      'PortBindings' => {},
+       'RestartPolicy' => {
+         'Name' => 'always',
+       }
+     })
+  end
+
+  it 'accepts "on-failure" restart policy with retry count' do
+    service = Centurion::Service.new(:redis)
+
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('on-failure', 50))).to eq({
+      'Binds' => [],
+      'PortBindings' => {},
+       'RestartPolicy' => {
+         'Name' => 'on-failure',
+         'MaximumRetryCount' => 50
+       }
+     })
+  end
+
+  it 'builds docker configuration for volume binds' do
+    service.add_volume('/volumes/redis/data', '/data')
+    expect(service.volume_binds_config).to eq(['/volumes/redis/data:/data'])
+  end
+
+  it 'builds docker configuration for port bindings' do
+    service.add_port_bindings(8000, 6379, 'tcp', '127.0.0.1')
+    expect(service.port_bindings_config).to eq({
+      '6379/tcp' => [{'HostPort' => '8000', 'HostIp' => '127.0.0.1'}]
+    })
+  end
+
+  it 'builds docker configuration for port bindings without host ip' do
+    service.add_port_bindings(8000, 6379, 'tcp')
+    expect(service.port_bindings_config).to eq({
+      '6379/tcp' => [{'HostPort' => '8000'}]
+    })
+  end
+end
+


### PR DESCRIPTION
Working towards having multiple services running on a single host, I moved the code a bit and created a Centurion::Service:

- It will help later, because we can switch to building multiple services in the DSL and all service attributes, like command, volumes, port mappings and other will have a logical place where they can be put, instead of being just global variables.
- I like that it also drastically reduces the length of the parameter list for most of the methods in `deploy.rb`. 
- As a bonus, all of the `fetch` calls are now contained within the rake files and deploy DSL and the variables are passed to the lower layers from there, instead of being pulled from other layers at will.
- Ports and volumes are stored verbatim, within the Service instance. Previously, they were immediately converted to the docker API format and then had to be parsed back in order to work with them. Now, they are converted to the docker API format only when needed, which further simplifies some parts of the code.

I tried to maintain the same behavior, and moved all the relevant tests from `deploy_spec.rb` to `service_spec.rb`. I did not retain the specific exit codes when wrong cpu shares or memory is specified though and changed that to raising an exception instead. I think that it was only used for testing purposes, but I can move it back if it was critical.

What do you think?