### PR TITLE
Fix container naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,17 +176,33 @@ With this, the container will be named something like `backend-4f692997`.
 ### Container Hostnames
 
 If you don't specify a hostname to use inside your container, the container
-will be given the hostname of the Docker server. This probably is good for
+will be given a hostname matching the container ID. This probably is good for
 a lot of situations, but it might not be good for yours. If you need to have
-a specific hostname, you can cause Centurion to do that:
+a specific hostname, you can ask Centurion to do that:
 
 ```ruby
 set :container_hostname, 'yourhostname'
 ```
 
-This is currently pretty inflexible in that the hostname will now be the same
-on all of your hosts. A possible future addition is the ability to pass
-a block to be evaluated on each host.
+That will make *all* of your containers named 'yourhostname'. If you want to do
+something more dynamic, you can pass a `Proc` or a lambda like this:
+
+```ruby
+set :container_hostname, ->(hostname) { "#{hostname}.example.com" }
+```
+
+The lambda will be passed the current server's hostname. So, this example will
+cause ".example.com" to be appended to the hostname of each Docker host during
+deployment.
+
+*If you want to restore the old behavior from Centurion 1.6.0* and earlier, you
+can do the following:
+
+```ruby
+set :container_hostname, ->(hostname) { hostname }
+```
+
+That will cause the container hostname to match the server's hostname.
 
 ### CGroup Resource Constraints
 

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -87,8 +87,17 @@ module Centurion::Deploy
     end
   end
 
+  def hostname_proc
+    hostname = fetch(:container_hostname)
+    if hostname.respond_to?(:call)
+      hostname
+    else
+      ->{ hostname }
+    end
+  end
+
   def start_new_container(server, service, restart_policy)
-    container_config = service.build_config(server.hostname)
+    container_config = service.build_config(server.hostname, &hostname_proc)
     info "Creating new container for #{container_config['Image'][0..7]}"
     container = server.create_container(container_config, service.name)
 


### PR DESCRIPTION
This will cause the default naming behavior of Centurion to change: it will no longer set the container hostname to match the hostname of the server by default. It also adds the ability to pass a `Proc` or a lambda to Centurion to dynamically assign the hostname. This change is needed to allow New Relic's new Docker support to work properly with Centurion-deployed applications.

I intend to merge this on Friday. I will then release Centurion 1.7.0 with these changes and will put a release note explaining the change.

cc @didp @jessedearing @kremso 