### PR TITLE
Fix wrong number of params for hostname proc

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Your name could be here!
  * [Matt Sanford][mzsanford]
  * [Suren Karapetyan][skarap]
  * [Jon Wood][jellybob]
+ * [Mark Borcherding][markborcherding]
 
 Pre-release
 -----------
@@ -71,3 +72,4 @@ Contributor                                   | Commits    | Additions | Deletio
 [mzsanford]: https://github.com/mzsanford
 [skarap]: https://github.com/skarap
 [jellybob]: https://github.com/jellybob
+[markborcherding]: https://github.com/markborcherding

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -87,17 +87,17 @@ module Centurion::Deploy
     end
   end
 
-  def hostname_proc
+  def container_hostname(server_name)
     hostname = fetch(:container_hostname)
     if hostname.respond_to?(:call)
-      hostname
+      hostname.call(server_name)
     else
-      ->{ hostname }
+      hostname
     end
   end
 
   def start_new_container(server, service, restart_policy)
-    container_config = service.build_config(server.hostname, &hostname_proc)
+    container_config = service.build_config(server.hostname, container_hostname(server.hostname))
     info "Creating new container for #{container_config['Image'][0..7]}"
     container = server.create_container(container_config, service.name)
 

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -63,10 +63,11 @@ module Centurion
       @image = image
     end
 
-    def build_config(server_hostname, &block)
+    def build_config(server_hostname, hostname = nil)
+
       container_config = {}.tap do |c|
         c['Image'] = image
-        c['Hostname'] = yield server_hostname if block_given?
+        c['Hostname'] = hostname if hostname
         c['Cmd'] = command if command
         c['Memory'] = memory if memory
         c['CpuShares'] = cpu_shares if cpu_shares

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -153,21 +153,23 @@ describe Centurion::Deploy do
   end
 
   describe '#container_hostname' do
+    let(:server_name) { 'server.com' }
+
     it 'does not provide a container hostname if no override is given' do
-      expect(test_deploy.container_hostname('foo')).to be_nil
+      expect(test_deploy.container_hostname(server_name)).to be_nil
     end
 
     context 'container_hostname is overridden with a string' do
-      it 'does not provide a container hostname if no override is given' do
-        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return 'hiya'
-        expect(test_deploy.container_hostname('foo')).to eq('hiya')
+      it 'provides container hostname if an overrided is given' do
+        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return 'container.com'
+        expect(test_deploy.container_hostname(server_name)).to eq('container.com')
       end
     end
 
     context 'container_hostname is overridden with a proc' do
-      it 'does not provide a container hostname if no override is given' do
-        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return ->(s) { "#{s}bar" }
-        expect(test_deploy.container_hostname('foo')).to eq('foobar')
+      it 'provides a container hostname by executing the proc given' do
+        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return ->(s) { "container.#{s}" }
+        expect(test_deploy.container_hostname(server_name)).to eq('container.server.com')
       end
     end
   end

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -20,7 +20,6 @@ describe Centurion::Deploy do
 
   before do
     allow(test_deploy).to receive(:fetch).and_return nil
-    allow(test_deploy).to receive(:fetch).with(:container_hostname, hostname).and_return(hostname)
     allow(test_deploy).to receive(:host_ip).and_return('172.16.0.1')
   end
 

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -153,6 +153,26 @@ describe Centurion::Deploy do
     end
   end
 
+  describe '#container_hostname' do
+    it 'does not provide a container hostname if no override is given' do
+      expect(test_deploy.container_hostname('foo')).to be_nil
+    end
+
+    context 'container_hostname is overridden with a string' do
+      it 'does not provide a container hostname if no override is given' do
+        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return 'hiya'
+        expect(test_deploy.container_hostname('foo')).to eq('hiya')
+      end
+    end
+
+    context 'container_hostname is overridden with a proc' do
+      it 'does not provide a container hostname if no override is given' do
+        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return ->(s) { "#{s}bar" }
+        expect(test_deploy.container_hostname('foo')).to eq('foobar')
+      end
+    end
+  end
+
   describe '#start_new_container' do
     let(:bindings) { {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]} }
     let(:env)      { { 'FOO' => 'BAR' } }

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -107,7 +107,7 @@ describe Centurion::Service do
       })
     end
 
-    it 'overrides the default hostname when passed a block' do
+    it 'overrides the default hostname when passed a container hostname' do
       expect(service.build_config('example.com', 'host.example.com')).to eq({
         'Image' => 'http://registry.hub.docker.com/library/redis',
         'Hostname' => 'host.example.com',

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -108,7 +108,7 @@ describe Centurion::Service do
     end
 
     it 'overrides the default hostname when passed a block' do
-      expect(service.build_config('example.com') { |s| "host.#{s}" }).to eq({
+      expect(service.build_config('example.com', 'host.example.com')).to eq({
         'Image' => 'http://registry.hub.docker.com/library/redis',
         'Hostname' => 'host.example.com',
         'Cmd' => ['redis-server', '--appendonly', 'yes'],


### PR DESCRIPTION
Version 1.7.0 broke deploys that did not set the hostname via a proc. That code didn't have tests around it either.

This patch simplifies that override and contains the proc/string evaluation overrides to one place.