### PR TITLE
Make hostnaming work properly, add tests.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Your name could be here!
  * [Matt Sanford][mzsanford]
  * [Suren Karapetyan][skarap]
  * [Jon Wood][jellybob]
+ * [Mark Borcherding][markborcherding]
 
 Pre-release
 -----------
@@ -71,3 +72,4 @@ Contributor                                   | Commits    | Additions | Deletio
 [mzsanford]: https://github.com/mzsanford
 [skarap]: https://github.com/skarap
 [jellybob]: https://github.com/jellybob
+[markborcherding]: https://github.com/markborcherding

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -89,10 +89,12 @@ module Centurion::Deploy
 
   def hostname_proc
     hostname = fetch(:container_hostname)
+    return nil if hostname.nil?
+
     if hostname.respond_to?(:call)
       hostname
     else
-      ->(hostname) { hostname }
+      ->(h) { hostname }
     end
   end
 

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -20,7 +20,6 @@ describe Centurion::Deploy do
 
   before do
     allow(test_deploy).to receive(:fetch).and_return nil
-    allow(test_deploy).to receive(:fetch).with(:container_hostname, hostname).and_return(hostname)
     allow(test_deploy).to receive(:host_ip).and_return('172.16.0.1')
   end
 
@@ -150,6 +149,25 @@ describe Centurion::Deploy do
       expect(test_deploy).to receive(:sleep).with(timing)
 
       test_deploy.wait_for_load_balancer_check_interval
+    end
+  end
+
+  describe '#hostname_proc' do
+    it 'does not provide a container hostname if no override is given' do
+      expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return nil
+      expect(test_deploy.hostname_proc).to be_nil
+    end
+
+    it 'provides container hostname if an override string is given' do
+      expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return 'example.com'
+      expect(test_deploy.hostname_proc.call('foo')).to eq('example.com')
+    end
+
+    context 'container_hostname is overridden with a proc' do
+      it 'provides a container hostname by executing the proc given' do
+        expect(test_deploy).to receive(:fetch).with(:container_hostname).and_return ->(s) { "container.#{s}" }
+        expect(test_deploy.hostname_proc.call('example.com')).to eq('container.example.com')
+      end
     end
   end
 


### PR DESCRIPTION
This fixes the dynamic hostnaming and uses many of the tests from #119.

Based on work contributed by @MarkBorcherding on #119.