### PR TITLE
Cleaner output

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -109,7 +109,7 @@ module Centurion::Deploy
     server.start_container(container['Id'], host_config)
 
     info "Inspecting new container #{container['Id'][0..7]}:"
-    server.inspect_container(container['Id']).each_pair do |key,value|
+    (server.inspect_container(container['Id']) || {}).each_pair do |key,value|
       info "\t#{key} => #{value.inspect}"
     end
 

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -109,7 +109,9 @@ module Centurion::Deploy
     server.start_container(container['Id'], host_config)
 
     info "Inspecting new container #{container['Id'][0..7]}:"
-    info server.inspect_container(container['Id'])
+    server.inspect_container(container['Id']).each_pair do |key,value|
+      info "\t#{key} => #{value.inspect}"
+    end
 
     container
   end

--- a/lib/centurion/dogestry.rb
+++ b/lib/centurion/dogestry.rb
@@ -17,10 +17,10 @@ class Centurion::Dogestry
   def which(cmd)
     exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
     ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-      exts.each { |ext|
+      exts.each do |ext|
         exe = File.join(path, "#{cmd}#{ext}")
         return exe if File.executable?(exe) && !File.directory?(exe)
-      }
+      end
     end
     return nil
   end


### PR DESCRIPTION
This changes the output for the `inspect_container` during deployment so that it looks much more like the image inspect we do earlier. It's more readable but doesn't try to do a full pretty-print so that it doesn't absolutely spam the output.

sidekick @kremso @didip