### PR TITLE
Fix broken tagging

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -71,14 +71,7 @@ module Centurion::DeployDSL
   end
 
   def defined_service
-    fetch(:service,
-      Centurion::Service.from_hash(
-        fetch(:project),
-        image:    fetch(:image),
-        hostname: fetch(:container_hostname),
-        dns:      fetch(:custom_dns)
-      )
-    )
+    fetch(:service, create_service)
   end
 
   def defined_health_check
@@ -94,18 +87,26 @@ module Centurion::DeployDSL
 
   private
 
-  def service_under_construction
-    service = fetch(:service,
-      Centurion::Service.from_hash(
-        fetch(:project),
-        image:    fetch(:image),
-        hostname: fetch(:container_hostname),
-        dns:      fetch(:custom_dns)
-      )
+  def create_service
+    image = if (tag = fetch(:tag))
+      "#{fetch(:image)}:#{tag}"
+    else
+      fetch(:image)
+    end
+
+    Centurion::Service.from_hash(
+      fetch(:project),
+      image:    image,
+      hostname: fetch(:container_hostname),
+      dns:      fetch(:custom_dns)
     )
-    set(:service, service)
+
   end
 
+  def service_under_construction
+    service = fetch(:service, create_service)
+    set(:service, service)
+  end
 
   def build_server_group
     hosts, docker_path = fetch(:hosts, []), fetch(:docker_path)

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -111,4 +111,10 @@ describe Centurion::DeployDSL do
 
     expect(DeployDSLTest.get_current_tags_for('asdf')).to eq [ { server: 'host1', tags: [ 'foo'] } ]
   end
+
+  it 'appends tags to the image name when returning a service' do
+    DeployDSLTest.set(:tag, 'roland')
+    DeployDSLTest.set(:image, 'charlemagne')
+    expect(DeployDSLTest.defined_service.image).to eq('charlemagne:roland')
+  end
 end


### PR DESCRIPTION
Tags are not getting passed properly through Centurion on 1.7.0-1.7.4. This fixes that by making sure we never pass the daemon the image without the tag. Adds a test to validate it also as it looks like we had a gap in test coverage around this.

sidekick @didip @kremso 