### PR TITLE
Dry run capability back in

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -33,6 +33,7 @@ opts = Trollop::options do
   opt :registry_user,    'user for registry auth',               type: String, short: :none
   opt :registry_password,'password for registry auth',           type: String, short: :none
   opt :override_env,     'override environment variables, comma separated', type: String
+  opt :dry_run,          'print out docker command do run',      type: :flag, default: false, short: :none
 end
 
 set_current_environment(opts[:environment].to_sym)
@@ -77,4 +78,8 @@ set :registry_user, opts[:registry_user] if opts[:registry_user]
 set :registry_password, opts[:registry_password] if opts[:registry_password]
 
 invoke('centurion:setup')
+if opts[:dry_run] 
+  Centurion::DryRunner.new(env).run
+  exit
+end
 invoke(opts[:action])

--- a/lib/centurion/dry_runner.rb
+++ b/lib/centurion/dry_runner.rb
@@ -1,0 +1,53 @@
+module Centurion
+  class DryRunner
+    def initialize(env)
+      environment = env[:current_environment]
+      @options = env[environment]
+    end
+
+    def run
+      puts result
+    end
+
+    private
+
+    attr_reader :options
+
+    def result
+      hosts.map do |host|
+        string = "docker -H=tcp://#{host}:2375 run"
+
+        string << environment_vars unless env_vars.empty?
+        string << ports_vars unless ports_vars.empty?
+        string
+      end.join("\n\n\n ******* \n\n\n")
+    end
+
+    def env_vars
+      [*options[:env_vars]]
+    end
+
+    def environment_vars
+      env_vars.reduce('') do |string, (k, v)|
+        " -e #{k.split('"')[0]}='#{v.gsub(/\n/, '')}'#{string}"
+      end.rstrip
+    end
+
+    def ports
+      [*options[:port_bindings]]
+    end
+
+    def hosts
+      [*options[:hosts]]
+    end
+
+    def ports_vars
+      ports.reduce('') do |string, port_binding|
+        protocol = port_binding.type
+        host_port = port_binding.host_port
+        container_port = port_binding.container_port
+        " -p #{host_port}:#{container_port}/#{protocol}#{string}"
+      end.rstrip
+    end
+  end
+end

--- a/spec/dry_runner_spec.rb
+++ b/spec/dry_runner_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'pry'
+
+describe Centurion::DryRunner do
+  before do
+    Singleton.__init__(Capistrano::DSL::Env::Store)
+  end
+
+  before do
+    env[:current_environment] = :test
+    env[:test] = {
+      project: 'test_project',
+      hosts: %w(example.com)
+    }
+  end
+
+  let(:env) do
+    Singleton.__init__(Capistrano::DSL::Env::Store).instance
+  end
+
+  subject { described_class.new(env).send(:result) }
+
+  context 'nothing is present' do
+    it 'does not error out' do
+      expect(subject).to eql 'docker -H=tcp://example.com:2375 run'
+    end
+  end
+
+  context 'with environment variables' do
+    before do
+      env[:test][:env_vars] = { 'hello' => 'world' }
+    end
+    it 'prints out the host' do
+      expect(subject).to match(/hello='world'/)
+    end
+  end
+
+  context 'with ports' do
+    before do
+      env[:test][:port_bindings] = [Centurion::Service::PortBinding.new(23, 32, 'foo', '0.0.0.0')]
+    end
+
+    it 'prints out the host' do
+      expect(subject).to match(%r{-p 23:32/foo})
+    end
+  end
+end


### PR DESCRIPTION
I know there are some issues with upgrading this. If we start putting changing representations of ports or somthing, it may not be future compatible. What we should do is put some contraints on how `Centurion::DSL::Env::Store` is represented, then tests may become future proof.
