### PR TITLE
List all containers in order to let non-running containers get cleaned up

### DIFF
--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -42,7 +42,7 @@ class Centurion::DockerServer
   end
 
   def find_containers_by_name(wanted_name)
-    ps.select do |container|
+    ps(all: true).select do |container|
       next unless container && container['Names']
       container['Names'].find do |name|
         name =~ /\A\/#{wanted_name}(-[a-f0-9]{14})?\Z/

--- a/spec/docker_server_spec.rb
+++ b/spec/docker_server_spec.rb
@@ -67,6 +67,7 @@ describe Centurion::DockerServer do
     end
 
     it 'finds containers by name' do
+      expect(server).to receive(:ps).with(all: true).and_return(ps)
       expect(server.find_containers_by_name('centurion')).to eq([container])
     end
 


### PR DESCRIPTION
The previous containers are not getting deleted because only running containers are being returned if we do not pass the `:all` flag to `#ps`.