### PR TITLE
Add support for container restart through server API.

### DIFF
--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -15,7 +15,7 @@ class Centurion::DockerServer
 
   def_delegators :docker_via_api, :create_container, :inspect_container,
                  :inspect_image, :ps, :start_container, :stop_container,
-                 :remove_container
+                 :remove_container, :restart_container
   def_delegators :docker_via_cli, :pull, :tail, :attach
 
   def initialize(host, docker_path, tls_params = {})

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -87,6 +87,24 @@ class Centurion::DockerViaApi
     end
   end
 
+  def restart_container(container_id, timeout = 30)
+    path = "/v1.10/containers/#{container_id}/restart?t=#{timeout}"
+    response = Excon.post(
+      @base_uri + path,
+      tls_excon_arguments
+    )
+    case response.status
+    when 204
+      true
+    when 404
+      fail "Failed to start missing container! \"#{response.body}\""
+    when 500
+      fail "Failed to start existing container! \"#{response.body}\""
+    else
+      raise response.inspect
+    end
+  end
+
   def inspect_container(container_id)
     path = "/v1.7/containers/#{container_id}/json"
     response = Excon.get(

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -74,6 +74,20 @@ describe Centurion::DockerViaApi do
       api.stop_container('12345')
     end
 
+    it 'restarts a container' do
+      expect(Excon).to receive(:post).
+                          with(excon_uri + "v1.10" + "/containers/12345/restart?t=30", {}).
+                          and_return(double(body: json_string, status: 204))
+      api.restart_container('12345')
+    end
+
+    it 'restarts a container with a custom timeout' do
+      expect(Excon).to receive(:post).
+                          with(excon_uri + "v1.10" + "/containers/12345/restart?t=300", {}).
+                          and_return(double(body: json_string, status: 204))
+      api.restart_container('12345', 300)
+    end
+
     it 'inspects a container' do
       expect(Excon).to receive(:get).
                            with(excon_uri + 'v1.7/containers/12345/json', {}).
@@ -175,6 +189,24 @@ describe Centurion::DockerViaApi do
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
       api.stop_container('12345')
+    end
+
+    it 'restarts a container' do
+      expect(Excon).to receive(:post).
+                        with(excon_uri + "v1.10" + "/containers/12345/restart?t=30",
+                            client_cert: '/certs/cert.pem',
+                            client_key: '/certs/key.pem').
+                        and_return(double(body: json_string, status: 204))
+      api.restart_container('12345')
+    end
+
+    it 'restarts a container with a custom timeout' do
+      expect(Excon).to receive(:post).
+                        with(excon_uri + "v1.10" + "/containers/12345/restart?t=300",
+                            client_cert: '/certs/cert.pem',
+                            client_key: '/certs/key.pem').
+                        and_return(double(body: json_string, status: 204))
+      api.restart_container('12345', 300)
     end
 
     it 'inspects a container' do


### PR DESCRIPTION
The Docker server API supports restarting an existing container without passing in a new host_config block. This allows the creation of workflow tasks that perform container restarts.