### PR TITLE
Add support for set :network_mode to allow host networking in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ set :container_hostname, ->(hostname) { hostname }
 
 That will cause the container hostname to match the server's hostname.
 
+### Network modes
+
+You may specify the network mode you would like a container to use via:
+
+```ruby
+set :network_mode, 'networkmode'
+```
+
+Docker (and therefore Centurion) supports one of `bridge` (the default), `host`,
+and `container:<container-id>` for this argument.
+
+*Note:* While host_port remains required, the mappings specified in it are
+*ignored* when using `host` and `container...` network modes.
+
 ### CGroup Resource Constraints
 
 Limits on memory and CPU can be specified with the `memory` and `cpu_shares`

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -66,6 +66,10 @@ module Centurion::DeployDSL
     end)
   end
 
+  def network_mode(mode)
+    set(:network_mode, fetch(:network_mode, 'bridge'))
+  end
+
   def public_port_for(port_bindings)
     # {'80/tcp'=>[{'HostIp'=>'0.0.0.0', 'HostPort'=>'80'}]}
     first_port_binding = port_bindings.values.first

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -67,7 +67,11 @@ module Centurion::DeployDSL
   end
 
   def network_mode(mode)
-    set(:network_mode, fetch(:network_mode, 'bridge'))
+    if %w(bridge host).include?(mode) or mode =~ /container.*/
+      set(:network_mode, mode)
+    else
+      abort("invalid value for network_mode: #{mode}, value must be one of 'bridge', 'host', or 'container:<name|id>'")
+    end
   end
 
   def public_port_for(port_bindings)

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -20,11 +20,12 @@ module Centurion
 
     def self.from_env
       Service.new(fetch(:name)).tap do |s|
-        s.image    = if fetch(:tag, nil)
+        s.image = if fetch(:tag, nil)
           "#{fetch(:image, nil)}:#{fetch(:tag)}"
         else
           fetch(:image, nil)
         end
+
         s.cap_adds      = fetch(:cap_adds, [])
         s.cap_drops     = fetch(:cap_drops, [])
         s.dns           = fetch(:dns, nil)
@@ -62,13 +63,10 @@ module Centurion
         raise ArgumentError, "invalid value for capability drops: #{capabilites}, value must be an array"
       end
       @cap_drops = capabilites
+    end
 
     def network_mode=(mode)
-      if ['bridge', 'host'].include?(mode) or mode =~ /container.*/
-        @network_mode = mode
-      else
-        raise ArgumentError, "invalid value for network_mode: #{mode}, value must be one of 'bridge', 'host', or 'container:<name|id>"
-      end
+      @network_mode = mode
     end
 
     def memory=(bytes)

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -118,6 +118,27 @@ describe Centurion::DeployDSL do
     end
   end
 
+  describe '#network_mode' do
+    it 'accepts host mode' do
+      DeployDSLTest.network_mode('host')
+      expect(DeployDSLTest.defined_service.network_mode).to eq('host')
+    end
+
+    it 'accepts bridge mode' do
+      DeployDSLTest.network_mode('bridge')
+      expect(DeployDSLTest.defined_service.network_mode).to eq('bridge')
+    end
+
+    it 'accepts container link mode' do
+      DeployDSLTest.network_mode('container:a2e8937b')
+      expect(DeployDSLTest.defined_service.network_mode).to eq('container:a2e8937b')
+    end
+
+    it 'fails when invalid mode is passed' do
+      expect { DeployDSLTest.network_mode('foo') }.to raise_error(SystemExit)
+    end
+  end
+
   describe '#host_volume' do
     it 'raises unless passed the container_volume option' do
       expect { DeployDSLTest.host_volume('foo', {}) }.to raise_error(ArgumentError, /:container_volume/)

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -255,10 +255,12 @@ describe Centurion::Service do
     })
   end
 
-  it 'builds docker configuration for container-linked networking' do 
+  it 'builds docker configuration for container-linked networking' do
     service.network_mode = 'container:a2e8937b'
     expect(service.build_host_config(Centurion::Service::RestartPolicy.new('on-failure', 50))).to eq({
       'Binds' => [],
+      'CapAdd' => [],
+      'CapDrop' => [],
       'NetworkMode' => 'container:a2e8937b',
       'PortBindings' => {},
        'RestartPolicy' => {
@@ -267,5 +269,20 @@ describe Centurion::Service do
       }
    })
   end
-end
 
+  it 'builds docker configuration for host networking' do
+    service.network_mode = 'host'
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('on-failure', 50))).to eq({
+      'Binds' => [],
+      'CapAdd' => [],
+      'CapDrop' => [],
+      'NetworkMode' => 'host',
+      'PortBindings' => {},
+       'RestartPolicy' => {
+         'Name' => 'on-failure',
+         'MaximumRetryCount' => 50
+      }
+   })
+  end
+
+end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -93,6 +93,7 @@ describe Centurion::Service do
       service.cpu_shares = 512
       service.add_env_vars(SLAVE_OF: '127.0.0.2')
       service.add_port_bindings(8000, 6379, 'tcp', '10.0.0.1')
+      service.network_mode = 'host'
       service.add_volume('/volumes/redis.8000', '/data')
 
     it 'builds a valid docker container configuration' do
@@ -164,6 +165,7 @@ describe Centurion::Service do
       'PortBindings' => {
         '6379/tcp' => [{'HostPort' => '8000'}]
       },
+      'NetworkMode' => 'bridge',
       'Dns' => 'example.com',
       'RestartPolicy' => {
         'Name' => 'on-failure',
@@ -180,6 +182,7 @@ describe Centurion::Service do
        'CapAdd' => [],
        'CapDrop' => [],
        'PortBindings' => {},
+       'NetworkMode' => 'bridge',
        'RestartPolicy' => {
          'Name' => 'on-failure',
          'MaximumRetryCount' => 10
@@ -195,6 +198,7 @@ describe Centurion::Service do
       'CapAdd' => [],
       'CapDrop' => [],
       'PortBindings' => {},
+      'NetworkMode' => 'bridge',
        'RestartPolicy' => {
          'Name' => 'no',
        }
@@ -209,6 +213,7 @@ describe Centurion::Service do
       'CapAdd' => [],
       'CapDrop' => [],
       'PortBindings' => {},
+      'NetworkMode' => 'bridge',
        'RestartPolicy' => {
          'Name' => 'always',
        }
@@ -222,6 +227,7 @@ describe Centurion::Service do
       'Binds' => [],
       'CapAdd' => [],
       'CapDrop' => [],
+      'NetworkMode' => 'bridge',
       'PortBindings' => {},
        'RestartPolicy' => {
          'Name' => 'on-failure',
@@ -247,6 +253,19 @@ describe Centurion::Service do
     expect(service.port_bindings_config).to eq({
       '6379/tcp' => [{'HostPort' => '8000'}]
     })
+  end
+
+  it 'builds docker configuration for container-linked networking' do 
+    service.network_mode = 'container:a2e8937b'
+    expect(service.build_host_config(Centurion::Service::RestartPolicy.new('on-failure', 50))).to eq({
+      'Binds' => [],
+      'NetworkMode' => 'container:a2e8937b',
+      'PortBindings' => {},
+       'RestartPolicy' => {
+         'Name' => 'on-failure',
+         'MaximumRetryCount' => 50
+      }
+   })
   end
 end
 


### PR DESCRIPTION
This lets you create host-networked containers for improved network performance and single-tenant docker hosts. The interaction with host_port is kind of weird but it seems to work just fine at least in newer dockers.