### PR TITLE
Attempt to stop containers by name, then public_ports.

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -7,7 +7,9 @@ module Centurion::Deploy
   FAILED_CONTAINER_VALIDATION = 100
 
   def stop_containers(target_server, service, timeout = 30)
-    old_containers = target_server.find_containers_by_public_port(service.public_ports.first)
+    old_containers = target_server.find_containers_by_name(service.name) || 
+                     target_server.find_containers_by_public_port(service.public_ports.first)
+
     info "Stopping container(s): #{old_containers.inspect}"
 
     old_containers.each do |old_container|


### PR DESCRIPTION
This allows host-based networking containers to be stopped, but retains backwards compatibility with old releases that did not give service names.