### PR TITLE
Make rolling deploy task correctly use wait_for_health_check_ok

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -127,6 +127,8 @@ namespace :deploy do
           container['Id'],
           port,
           fetch(:status_endpoint, '/'),
+          fetch(:image),
+          fetch(:tag),
           fetch(:rolling_deploy_wait_time, 5),
           fetch(:rolling_deploy_retries, 24)
         )


### PR DESCRIPTION
The rolling deploy task stopped passing image and tag parameters to
wait_for_health_check_ok in 32f54ef52984ae1c677643948793026c2e7d2368.

Since the wait_for_health_check_ok method has two default parameters, it wasn't
causing errors, but instead it was causing the rolling deploy wait time and
retries count to be interpreted as image and tag. This in turn was relatively
harmless, since by default the image/tag parameters are not used at all.

The side effect of this bug is that rolling deploy configuration parameters
were being ignored.