### PR TITLE
Display the docker server hostname correctly when healthchecks fail

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -31,7 +31,7 @@ module Centurion::Deploy
     end
 
     unless health_check_method.call(target_server, port, endpoint)
-      error "Failed to validate started container on #{target_server}:#{port}"
+      error "Failed to validate started container on #{target_server.hostname}:#{port}"
       exit(FAILED_CONTAINER_VALIDATION)
     end
   end


### PR DESCRIPTION
When we fall off the end of timeouts loop, we try to show which host failed, but we're echoing the DockerServer object, not the hostname. Changes this:
```
Failed to validate started container on #<Centurion::DockerServer:0x007fdde99b4708>:8778
```

To this:
```
Failed to validate started container on aws-docker-1.example.com:8778
```