### PR TITLE
Add support for the CENTURION_CONFIG_HOME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ well with the hand-off in many organizations between the build and deploy
 steps. If you only have one application, or don't need this you can
 decentralize the config into each repo.
 
-It will look for configuration files in either `./config/centurion` or `.`.
+It will look for configuration files in the following paths:
+- `$CENTURION_CONFIG_HOME/config/centurion`
+- `$CENTURION_CONFIG_HOME`
+- `./config/centurion`
+- `.`
 
 The pattern at New Relic is to have a configs repo with a `Gemfile` that
 sources the Centurion gem. If you want Centurion to set up the structure for

--- a/bin/centurion
+++ b/bin/centurion
@@ -40,15 +40,7 @@ set :project, opts[:project]
 set :environment, opts[:environment]
 
 # Load the per-project config and execute the task for the current environment
-projects_dir = File.join(Dir.getwd(), 'config', 'centurion')
-config_file  = "#{opts[:project]}.rake"
-if File.exists?(File.join(projects_dir, config_file))
-  load File.join(File.join(projects_dir, config_file))
-elsif File.exists?(config_file)
-  load config_file
-else
-  raise "Can't find '#{config_file}'!"
-end
+Centurion::ProjectLoader.load_project(Dir.getwd(), opts[:project])
 invoke("environment:#{opts[:environment]}")
 
 # Override the config with command line values if given

--- a/lib/centurion/project_loader.rb
+++ b/lib/centurion/project_loader.rb
@@ -1,0 +1,52 @@
+module Centurion
+  module ProjectLoader
+
+    def self.load_project(working_directory, project_name)
+      lookup_path = build_lookup_path(working_directory, project_name)
+      project_file = lookup_path.detect { |path| File.exists?(path) }
+
+      if project_file
+        load(project_file)
+      else
+        raise FileNotFound.new(lookup_path)
+      end
+    end
+
+    def self.build_lookup_path(working_directory, project_name)
+      centurion_config_home = ENV["CENTURION_CONFIG_HOME"]
+      project_name = "#{project_name}.rake"
+      lookup_path = []
+
+      if centurion_config_home
+        lookup_path << build_path(centurion_config_home, "config", "centurion", project_name)
+        lookup_path << build_path(centurion_config_home, project_name)
+      end
+
+      lookup_path << build_path(working_directory, "config", "centurion", project_name)
+      lookup_path << build_path(working_directory, project_name)
+
+      lookup_path
+    end
+
+    def self.build_path(*segments)
+      path = File.join(segments)
+      File.expand_path(path)
+    end
+
+    class FileNotFound < StandardError
+
+      def initialize(lookup_path)
+        @lookup_path = lookup_path
+      end
+
+      def message
+        text = "\nCould not find a project file in any of the following locations: "
+        text << @lookup_path.map { |path| "\n  - #{path}" }.join
+        text << "\n\n" # Add a few lines of separation between the message and stack trace
+        text
+      end
+    end
+
+  end
+end
+

--- a/spec/project_loader_spec.rb
+++ b/spec/project_loader_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'centurion/project_loader'
+
+module Centurion
+  describe ProjectLoader do
+
+    describe "load_project" do
+      let(:centurion_config_home) { File.expand_path("../tmp/config/home", __FILE__) }
+      let(:root_dir) { File.expand_path("../tmp/working", __FILE__) }
+
+      before do
+        ENV["CENTURION_CONFIG_HOME"] = centurion_config_home
+        create_project_file("#{centurion_config_home}/config/centurion", "FIRST")
+        create_project_file(centurion_config_home, "SECOND")
+        create_project_file("#{root_dir}/config/centurion", "THIRD")
+        create_project_file(root_dir, "FOURTH")
+      end
+
+      after do
+        FileUtils.rm_rf(centurion_config_home)
+        FileUtils.rm_rf(root_dir)
+      end
+
+      it "loads the project file in CENTURION_CONFIG_HOME/config/centurion" do
+        ProjectLoader.load_project(root_dir, "foo")
+        expect(ProjectLoaderTest.hello).to eql("FIRST")
+      end
+
+      it "loads the project file in CENTURION_CONFIG_HOME" do
+        FileUtils.rm_rf("#{centurion_config_home}/config/centurion")
+
+        ProjectLoader.load_project(root_dir, "foo")
+        expect(ProjectLoaderTest.hello).to eql("SECOND")
+      end
+
+      it "loads the project file in WORKING_DIR/config/centurion" do
+        FileUtils.rm_rf("#{centurion_config_home}/config/centurion")
+        FileUtils.rm_rf(centurion_config_home)
+
+        ProjectLoader.load_project(root_dir, "foo")
+        expect(ProjectLoaderTest.hello).to eql("THIRD")
+      end
+
+      it "loads the project file in WORKING_DIR" do
+        FileUtils.rm_rf("#{centurion_config_home}/config/centurion")
+        FileUtils.rm_rf(centurion_config_home)
+        FileUtils.rm_rf("#{root_dir}/config/centurion")
+
+        ProjectLoader.load_project(root_dir, "foo")
+        expect(ProjectLoaderTest.hello).to eql("FOURTH")
+      end
+
+      it "raises an error when the project file could not be found" do
+        FileUtils.rm_rf("#{centurion_config_home}/config/centurion")
+        FileUtils.rm_rf(centurion_config_home)
+        FileUtils.rm_rf("#{root_dir}/config/centurion")
+        FileUtils.rm_rf(root_dir)
+
+        expect { ProjectLoader.load_project(root_dir, "foo")
+        }.to raise_error(ProjectLoader::FileNotFound)
+      end
+
+      def create_project_file(directory, message)
+        FileUtils.mkdir_p(directory)
+        File.write "#{directory}/foo.rake", <<-MESSAGE
+          module ProjectLoaderTest
+            def self.hello
+              "#{message}"
+            end
+          end
+        MESSAGE
+      end
+    end
+
+    describe "lookup_path" do
+      before do
+        ENV["CENTURION_CONFIG_HOME"] = nil
+      end
+
+      it "adds the specified directory" do
+        expect(ProjectLoader.build_lookup_path("/tmp", "foo")).to eql([
+          "/tmp/config/centurion/foo.rake",
+          "/tmp/foo.rake"
+        ])
+      end
+
+      it "prepends the CENTURION_CONFIG_HOME when present" do
+        ENV["CENTURION_CONFIG_HOME"] = "/foo/bar"
+
+        expect(ProjectLoader.build_lookup_path("/tmp", "foo")).to eql([
+          "/foo/bar/config/centurion/foo.rake",
+          "/foo/bar/foo.rake",
+          "/tmp/config/centurion/foo.rake",
+          "/tmp/foo.rake"
+        ])
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Allow users to configure a CENTURION_CONFIG_HOME environment variable. It should contain the location of the centurion configs on their local system. Centurion will then look for project configs in this path whenever a command is executed. Thus allowing the centurion command to be run from anywhere in the system.

The presence of the variable would then change the lookup path. For example, if one were to export the following variable: `export CENTURION_CONFIG_HOME='~/checkouts/centurion_config'`, then the following locations are used to lookup the location of centurion project configs. Thus ensuring that we are not introducing a breaking change.

~/checkouts/centurion_config/config/centurion
~/checkouts/centurion_config/
./config/centurion
.
