### PR TITLE
Adds a method for finding the correct server to canary to.

### DIFF
--- a/lib/centurion/docker_server_group.rb
+++ b/lib/centurion/docker_server_group.rb
@@ -30,4 +30,84 @@ class Centurion::DockerServerGroup
 
     threads.each { |t| t.join }
   end
+
+  def get_current_tags_for(image)
+    return @hosts
+      .map { |host| ({ server: host.hostname, tags: host.current_tags_for(image) }) }
+      .filter { |host| host.tags }
+  end
+
+  def get_current_hosts_by_tag_for(image)
+    # ensure each server is only listed once
+    duplicate_hosts = @hosts
+      .group_by { |host| host.hostname }
+      .select { |hostname, hosts| hosts.size > 1 }
+    if duplicate_hosts.size != 0
+      raise "Found duplicate entries for a server: #{duplicate_hosts}"
+    end
+
+    # get all of the hosts that have the specified image already
+    host_and_tags_list = @hosts
+      .map { |host| ({ host: host, tags: host.current_tags_for(image) }) }
+      .select { |host_and_tags| host_and_tags[:tags].size > 0 }
+
+    # ensure each server has only one tag
+    hosts_with_multiple_tags = host_and_tags_list
+      .select { |host_and_tags| host_and_tags[:tags].size > 1 }
+    if hosts_with_multiple_tags.size != 0
+      raise "Found servers that had multiple tags: #{servers_with_multiple_tags}"
+    end
+    host_and_tag_list = host_and_tags_list
+      .map { |host_and_tags| ({ host: host_and_tags[:host], tag: host_and_tags[:tags][0] }) }
+
+    # return a map of servers associated with each tag like: { "tag1": ["host1","host2"], "tag2": ["host3"] }
+    hosts_by_tag = host_and_tag_list
+      .group_by { |host_and_tag| host_and_tag[:tag] }
+      .map { |tag, host_and_tag_grouping| [ tag, host_and_tag_grouping.map { |host_and_tag| host_and_tag[:host] } ] }
+      .to_h
+    hosts_by_tag
+  end
+
+  def find_existing_canary_for(image)
+    deployed_hosts_by_tag = get_current_hosts_by_tag_for(image)
+
+    # ensure enough servers to do a canary
+    if deployed_hosts_by_tag.values.flatten.size < 3
+      raise "Cannot canary to less than 3 servers because we wouldn't be able to tell which one was the canary once deployed."
+    end
+
+    # if there is only one image across all of the servers then canary to the first
+    if deployed_hosts_by_tag.size == 1
+      return nil
+    end
+
+    # ensure that there are only two different images deployed
+    if deployed_hosts_by_tag.size > 2
+      raise "There currently are more than 2 different docker images deployed right now.  Canary deployments can only happen in an environment that has either one or two different images deployed to it."
+    end
+
+    # get the tag for the current canary
+    canary_tag = deployed_hosts_by_tag.select { |tag, hosts| hosts.size == 1 }.keys.first
+
+    # ensure that there is an existing canary
+    if canary_tag.nil?
+      raise "Each of the two currently deployed docker images is deployed to 2 or more hosts so we cannot identify which server is the canary."
+    end
+
+    # return the existing canary server
+    return { tag: canary_tag, server: deployed_hosts_by_tag[canary_tag].first }
+  end
+
+  def get_currently_deployed_tag(image)
+    deployed_hosts_by_tag = get_current_hosts_by_tag_for(image)
+  
+    # if there is not a canary out then return the only tag or raise an error if the environment is in a bad state
+    canary_server = find_existing_canary_for(image)
+    if canary_server.nil?
+      return deployed_hosts_by_tag.keys.first
+    end
+
+    # return the other tag (the one that isn't the canary)
+    return deployed_hosts_by_tag.keys.select { |tag| tag != canary_server[:tag] }.first
+  end
 end

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -53,7 +53,7 @@ describe Centurion::DeployDSL do
     end
 
     it 'fails when an invalid capability is added' do
-      lambda{ DeployDSLTest.add_capability 'FOO_BAR' }.should raise_error SystemExit
+      expect { DeployDSLTest.add_capability 'FOO_BAR' }.to raise_error SystemExit
     end
   end
 
@@ -181,4 +181,5 @@ describe Centurion::DeployDSL do
     DeployDSLTest.set(:image, 'charlemagne')
     expect(DeployDSLTest.defined_service.image).to eq('charlemagne:roland')
   end
+
 end

--- a/spec/docker_server_group_spec.rb
+++ b/spec/docker_server_group_spec.rb
@@ -28,4 +28,224 @@ describe Centurion::DockerServerGroup do
 
     expect { group.each_in_parallel { |host| item.dummy_method } }.not_to raise_error
   end
+  
+  describe '#get_current_hosts_by_tag_for' do
+    let(:docker_path) { 'docker' }
+    let(:docker_server_1) { Centurion::DockerServer.new('host1', docker_path) }
+    let(:docker_server_2) { Centurion::DockerServer.new('host2', docker_path) }
+    let(:docker_server_3) { Centurion::DockerServer.new('host3', docker_path) }
+    let(:docker_server_group) {
+      docker_server_group = Centurion::DockerServerGroup.new(['placeholder'], docker_path)
+      docker_server_group.instance_variable_set(:@hosts, [ docker_server_1, docker_server_2, docker_server_3 ])
+      docker_server_group
+    }
+
+    it 'raises when a server has multiple tags' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1", "tag2"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag1"])
+
+      expect { docker_server_group.get_current_hosts_by_tag_for("image") }.to raise_error
+    end
+
+    it 'raises when there are duplicate server entries' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:hostname).and_return('host1')
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag1"])
+
+      expect { docker_server_group.get_current_hosts_by_tag_for("image") }.to raise_error
+    end
+
+    it 'returns no hosts when tags are empty' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return([])
+      allow(docker_server_2).to receive(:current_tags_for).and_return([])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+
+      actual_results = docker_server_group.get_current_hosts_by_tag_for("image")
+      expected_results = ({})
+      expect(actual_results).to eq expected_results
+    end
+
+    it 'maps servers by tag' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag2"])
+
+      actual_results = docker_server_group.get_current_hosts_by_tag_for("image")
+      expected_results = ({ "tag1" => [docker_server_1, docker_server_2], "tag2" => [docker_server_3] })
+      expect(actual_results).to eq expected_results
+    end
+  end
+
+  describe '#find_existing_canary_for' do
+    let(:docker_path) { 'docker' }
+    let(:docker_server_1) { Centurion::DockerServer.new('host1', docker_path) }
+    let(:docker_server_2) { Centurion::DockerServer.new('host2', docker_path) }
+    let(:docker_server_3) { Centurion::DockerServer.new('host3', docker_path) }
+    let(:docker_server_4) { Centurion::DockerServer.new('host4', docker_path) }
+    let(:docker_server_group) {
+      docker_server_group = Centurion::DockerServerGroup.new(['placeholder'], docker_path)
+      docker_server_group.instance_variable_set(:@hosts, [ docker_server_1, docker_server_2, docker_server_3, docker_server_4 ])
+      docker_server_group
+    }
+
+    it 'raises when there are no servers with the image' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return([])
+      allow(docker_server_2).to receive(:current_tags_for).and_return([])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.find_existing_canary_for("image") }.to raise_error
+    end
+
+    it 'raises when there is only one server with the image' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return([])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.find_existing_canary_for("image") }.to raise_error
+    end
+  
+    it 'raises when there are only two servers with the image and one tag' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.find_existing_canary_for("image") }.to raise_error
+    end
+
+    it 'raises when there are only two servers with the image and two tags' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.find_existing_canary_for("image") }.to raise_error
+    end
+
+    it 'raises when there are more than two tags' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag3"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.find_existing_canary_for("image") }.to raise_error
+    end
+
+    it 'raises when there are no tags deployed to only one server' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return(["tag2"])
+
+      expect { docker_server_group.find_existing_canary_for("image") }.to raise_error
+    end
+
+    it 'finds no canary when there is only one tag' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect(docker_server_group.find_existing_canary_for("image")).to be_nil 
+    end
+
+    it 'finds a canary' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return(["tag1"])
+      
+      expect(docker_server_group.find_existing_canary_for("image")).to eq ({ tag: 'tag2', server: docker_server_3 })
+    end
+  end
+
+  describe '#get_currently_deployed_tag' do
+    let(:docker_path) { 'docker' }
+    let(:docker_server_1) { Centurion::DockerServer.new('host1', docker_path) }
+    let(:docker_server_2) { Centurion::DockerServer.new('host2', docker_path) }
+    let(:docker_server_3) { Centurion::DockerServer.new('host3', docker_path) }
+    let(:docker_server_4) { Centurion::DockerServer.new('host4', docker_path) }
+    let(:docker_server_group) {
+      docker_server_group = Centurion::DockerServerGroup.new(['placeholder'], docker_path)
+      docker_server_group.instance_variable_set(:@hosts, [ docker_server_1, docker_server_2, docker_server_3, docker_server_4 ])
+      docker_server_group
+    }
+
+    it 'raises when there are no servers with the image' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return([])
+      allow(docker_server_2).to receive(:current_tags_for).and_return([])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.get_currently_deployed_tag("image") }.to raise_error
+    end
+
+    it 'raises when there is only one server with the image' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return([])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.get_currently_deployed_tag("image") }.to raise_error
+    end
+  
+    it 'raises when there are only two servers and one tag' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.get_currently_deployed_tag("image") }.to raise_error
+    end
+
+    it 'raises when there are only two servers and two tags' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return([])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.get_currently_deployed_tag("image") }.to raise_error
+    end
+
+    it 'raises when there are more than two tags' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag3"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect { docker_server_group.get_currently_deployed_tag("image") }.to raise_error
+    end
+
+    it 'raises when there are no tags deployed to only one server' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return(["tag2"])
+
+      expect { docker_server_group.get_currently_deployed_tag("image") }.to raise_error
+    end
+
+    it 'returns the only tag when there is only one tag' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect(docker_server_group.get_currently_deployed_tag("image")).to eq "tag1"
+    end
+
+    it 'returns non-canary tag when there are two tags' do
+      allow(docker_server_1).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_2).to receive(:current_tags_for).and_return(["tag1"])
+      allow(docker_server_3).to receive(:current_tags_for).and_return(["tag2"])
+      allow(docker_server_4).to receive(:current_tags_for).and_return([])
+
+      expect(docker_server_group.get_currently_deployed_tag("image")).to eq "tag2"
+    end
+  end
+
 end


### PR DESCRIPTION
This will be used in an upcoming PR to do canary deployments.  There are two scenarios where this will work.  First, if all of the servers have the same docker image deployed to them then it will just pick the first server as the canary.  If all of the servers have the same docker image deployed to them except for one, which has a different image, then it will choose that one as the canary.  This allows you to upgrade a canary without first broadly deploying or rolling back the existing canary.

The next step is to add a method that gets the current non-canary deployment image.  Then we can do nifty things like automatically rolling back a canary to align with the rest of the environment or promoting one environment's image (staging) to another (production).

Also fixes a deprecation warning in another test.