### PR TITLE
Add support for servers running exec via CLI

### DIFF
--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -16,7 +16,7 @@ class Centurion::DockerServer
   def_delegators :docker_via_api, :create_container, :inspect_container,
                  :inspect_image, :ps, :start_container, :stop_container,
                  :remove_container, :restart_container
-  def_delegators :docker_via_cli, :pull, :tail, :attach
+  def_delegators :docker_via_cli, :pull, :tail, :attach, :exec
 
   def initialize(host, docker_path, tls_params = {})
     @docker_path = docker_path

--- a/lib/centurion/docker_via_cli.rb
+++ b/lib/centurion/docker_via_cli.rb
@@ -27,6 +27,10 @@ class Centurion::DockerViaCli
     Centurion::Shell.echo(build_command(:attach, container_id))
   end
 
+  def exec(container_id, commandline)
+    Centurion::Shell.echo(build_command(:exec, "#{container_id} #{commandline}"))
+  end
+
   private
 
   def self.tls_keys
@@ -61,6 +65,7 @@ class Centurion::DockerViaCli
                when :pull then ' pull '
                when :logs then ' logs -f '
                when :attach then ' attach '
+               when :exec then ' exec '
                end
     command << destination
     command


### PR DESCRIPTION
This lets you do exciting things like make one-off exec tasks in your application rakefiles. Example:

```
  on_each_docker_host do |host|
    containers = host.find_containers_by_name('my_service')
    host.exec(containers.first['Id'], "rake db:migrate")
  end
```

This is radically incomplete but does actually work. One surprising element is that you're not running bash - it's not like Ansible - but for pre-baked maintenance tasks it gets the job done.