### PR TITLE
Basic support for docker 1.7 and 1.8

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Your name could be here!
  * [Suren Karapetyan][skarap]
  * [Jon Wood][jellybob]
  * [Mark Borcherding][markborcherding]
+ * [Nick Laferriere][laferrieren]
 
 Pre-release
 -----------

--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -64,7 +64,7 @@ class Centurion::DockerServer
 
   def docker_via_api
     @docker_via_api ||= Centurion::DockerViaApi.new(@hostname, @port,
-                                                    @tls_params)
+                                                    @tls_params, nil)
   end
 
   def docker_via_cli

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -14,7 +14,7 @@ class Centurion::DockerViaApi
   end
 
   def ps(options={})
-    path = "/v1.7" + "/containers/json"
+    path = "/v1.12" + "/containers/json"
     path += "?all=1" if options[:all]
     response = Excon.get(@base_uri + path, tls_excon_arguments)
 
@@ -24,7 +24,7 @@ class Centurion::DockerViaApi
 
   def inspect_image(image, tag = "latest")
     repository = "#{image}:#{tag}"
-    path       = "/v1.7" + "/images/#{repository}/json"
+    path       = "/v1.12" + "/images/#{repository}/json"
 
     response = Excon.get(
       @base_uri + path,
@@ -35,7 +35,7 @@ class Centurion::DockerViaApi
   end
 
   def remove_container(container_id)
-    path = "/v1.7" + "/containers/#{container_id}"
+    path = "/v1.12" + "/containers/#{container_id}"
     response = Excon.delete(
       @base_uri + path,
       tls_excon_arguments
@@ -45,7 +45,7 @@ class Centurion::DockerViaApi
   end
 
   def stop_container(container_id, timeout = 30)
-    path = "/v1.7" + "/containers/#{container_id}/stop?t=#{timeout}"
+    path = "/v1.12" + "/containers/#{container_id}/stop?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -55,7 +55,7 @@ class Centurion::DockerViaApi
   end
 
   def create_container(configuration, name = nil)
-    path = "/v1.10" + "/containers/create"
+    path = "/v1.12" + "/containers/create"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -69,7 +69,7 @@ class Centurion::DockerViaApi
   end
 
   def start_container(container_id, configuration)
-    path = "/v1.10" + "/containers/#{container_id}/start"
+    path = "/v1.12" + "/containers/#{container_id}/start"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -88,7 +88,7 @@ class Centurion::DockerViaApi
   end
 
   def restart_container(container_id, timeout = 30)
-    path = "/v1.10" + "/containers/#{container_id}/restart?t=#{timeout}"
+    path = "/v1.12" + "/containers/#{container_id}/restart?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -106,7 +106,7 @@ class Centurion::DockerViaApi
   end
 
   def inspect_container(container_id)
-    path = "/v1.7" + "/containers/#{container_id}/json"
+    path = "/v1.12" + "/containers/#{container_id}/json"
     response = Excon.get(
       @base_uri + path,
       tls_excon_arguments

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -14,7 +14,7 @@ class Centurion::DockerViaApi
   end
 
   def ps(options={})
-    path = "/v1.7/containers/json"
+    path = "/v1.7" + "/containers/json"
     path += "?all=1" if options[:all]
     response = Excon.get(@base_uri + path, tls_excon_arguments)
 
@@ -24,7 +24,7 @@ class Centurion::DockerViaApi
 
   def inspect_image(image, tag = "latest")
     repository = "#{image}:#{tag}"
-    path       = "/v1.7/images/#{repository}/json"
+    path       = "/v1.7" + "/images/#{repository}/json"
 
     response = Excon.get(
       @base_uri + path,
@@ -35,7 +35,7 @@ class Centurion::DockerViaApi
   end
 
   def remove_container(container_id)
-    path = "/v1.7/containers/#{container_id}"
+    path = "/v1.7" + "/containers/#{container_id}"
     response = Excon.delete(
       @base_uri + path,
       tls_excon_arguments
@@ -45,7 +45,7 @@ class Centurion::DockerViaApi
   end
 
   def stop_container(container_id, timeout = 30)
-    path = "/v1.7/containers/#{container_id}/stop?t=#{timeout}"
+    path = "/v1.7" + "/containers/#{container_id}/stop?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -55,7 +55,7 @@ class Centurion::DockerViaApi
   end
 
   def create_container(configuration, name = nil)
-    path = "/v1.10/containers/create"
+    path = "/v1.10" + "/containers/create"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -69,7 +69,7 @@ class Centurion::DockerViaApi
   end
 
   def start_container(container_id, configuration)
-    path = "/v1.10/containers/#{container_id}/start"
+    path = "/v1.10" + "/containers/#{container_id}/start"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -88,7 +88,7 @@ class Centurion::DockerViaApi
   end
 
   def restart_container(container_id, timeout = 30)
-    path = "/v1.10/containers/#{container_id}/restart?t=#{timeout}"
+    path = "/v1.10" + "/containers/#{container_id}/restart?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -106,7 +106,7 @@ class Centurion::DockerViaApi
   end
 
   def inspect_container(container_id)
-    path = "/v1.7/containers/#{container_id}/json"
+    path = "/v1.7" + "/containers/#{container_id}/json"
     response = Excon.get(
       @base_uri + path,
       tls_excon_arguments

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -6,15 +6,16 @@ require 'securerandom'
 module Centurion; end
 
 class Centurion::DockerViaApi
-  def initialize(hostname, port, tls_args = {})
+  def initialize(hostname, port, tls_args = {}, api_version = nil)
     @tls_args = default_tls_args(tls_args[:tls]).merge(tls_args.reject { |k, v| v.nil? }) # Required by tls_enable?
     @base_uri = "http#{'s' if tls_enable?}://#{hostname}:#{port}"
-
+    api_version ||= "/v1.12"
+    @docker_api_version = api_version
     configure_excon_globally
   end
 
   def ps(options={})
-    path = "/v1.12" + "/containers/json"
+    path = @docker_api_version + "/containers/json"
     path += "?all=1" if options[:all]
     response = Excon.get(@base_uri + path, tls_excon_arguments)
 
@@ -24,7 +25,7 @@ class Centurion::DockerViaApi
 
   def inspect_image(image, tag = "latest")
     repository = "#{image}:#{tag}"
-    path       = "/v1.12" + "/images/#{repository}/json"
+    path       = @docker_api_version + "/images/#{repository}/json"
 
     response = Excon.get(
       @base_uri + path,
@@ -35,7 +36,7 @@ class Centurion::DockerViaApi
   end
 
   def remove_container(container_id)
-    path = "/v1.12" + "/containers/#{container_id}"
+    path = @docker_api_version + "/containers/#{container_id}"
     response = Excon.delete(
       @base_uri + path,
       tls_excon_arguments
@@ -45,7 +46,7 @@ class Centurion::DockerViaApi
   end
 
   def stop_container(container_id, timeout = 30)
-    path = "/v1.12" + "/containers/#{container_id}/stop?t=#{timeout}"
+    path = @docker_api_version + "/containers/#{container_id}/stop?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -55,7 +56,7 @@ class Centurion::DockerViaApi
   end
 
   def create_container(configuration, name = nil)
-    path = "/v1.12" + "/containers/create"
+    path = @docker_api_version + "/containers/create"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -69,7 +70,7 @@ class Centurion::DockerViaApi
   end
 
   def start_container(container_id, configuration)
-    path = "/v1.12" + "/containers/#{container_id}/start"
+    path = @docker_api_version + "/containers/#{container_id}/start"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -88,7 +89,7 @@ class Centurion::DockerViaApi
   end
 
   def restart_container(container_id, timeout = 30)
-    path = "/v1.12" + "/containers/#{container_id}/restart?t=#{timeout}"
+    path = @docker_api_version + "/containers/#{container_id}/restart?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -106,7 +107,7 @@ class Centurion::DockerViaApi
   end
 
   def inspect_container(container_id)
-    path = "/v1.12" + "/containers/#{container_id}/json"
+    path = @docker_api_version + "/containers/#{container_id}/json"
     response = Excon.get(
       @base_uri + path,
       tls_excon_arguments

--- a/lib/centurion/version.rb
+++ b/lib/centurion/version.rb
@@ -1,3 +1,3 @@
 module Centurion
-  VERSION = '1.8.2'
+  VERSION = '1.8.3'
 end

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -13,14 +13,14 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.12/containers/json', {}).
+                       with(excon_uri + "v1.12" + "/containers/json", {}).
                        and_return(double(body: json_string, status: 200))
       expect(api.ps).to eq(json_value)
     end
 
     it 'lists all processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.12/containers/json?all=1', {}).
+                       with(excon_uri + "v1.12" + "/containers/json?all=1", {}).
                        and_return(double(body: json_string, status: 200))
       expect(api.ps(all: true)).to eq(json_value)
     end
@@ -62,14 +62,14 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.12/containers/12345/stop?t=300', {}).
+                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=300", {}).
                        and_return(double(status: 204))
       api.stop_container('12345', 300)
     end
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.12/containers/12345/stop?t=30', {}).
+                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=30", {}).
                        and_return(double(status: 204))
       api.stop_container('12345')
     end
@@ -90,14 +90,14 @@ describe Centurion::DockerViaApi do
 
     it 'inspects a container' do
       expect(Excon).to receive(:get).
-                           with(excon_uri + 'v1.12/containers/12345/json', {}).
+                           with(excon_uri + "v1.12" + "/containers/12345/json", {}).
                            and_return(double(body: json_string, status: 200))
       expect(api.inspect_container('12345')).to eq(json_value)
     end
 
     it 'removes a container' do
       expect(Excon).to receive(:delete).
-                           with(excon_uri + 'v1.12/containers/12345', {}).
+                           with(excon_uri + "v1.12" + "/containers/12345", {}).
                            and_return(double(status: 204))
       expect(api.remove_container('12345')).to eq(true)
     end
@@ -120,7 +120,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.12/containers/json',
+                       with(excon_uri + "v1.12" + "/containers/json",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(body: json_string, status: 200))
@@ -129,7 +129,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists all processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.12/containers/json?all=1',
+                       with(excon_uri + "v1.12" + "/containers/json?all=1",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(body: json_string, status: 200))
@@ -138,7 +138,7 @@ describe Centurion::DockerViaApi do
 
     it 'inspects an image' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.12/images/foo:bar/json',
+                       with(excon_uri + "v1.12" + "/images/foo:bar/json",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem',
                             headers: {'Accept' => 'application/json'}).
@@ -150,7 +150,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + 'v1.12/containers/create',
+                           with(excon_uri + "v1.12" + "/containers/create",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem',
                                 query: nil,
@@ -164,7 +164,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + 'v1.12/containers/12345/start',
+                           with(excon_uri + "v1.12" + "/containers/12345/start",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem',
                                 body: configuration_as_json,
@@ -175,7 +175,7 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.12/containers/12345/stop?t=300',
+                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=300",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
@@ -184,7 +184,7 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.12/containers/12345/stop?t=30',
+                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=30",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
@@ -211,7 +211,7 @@ describe Centurion::DockerViaApi do
 
     it 'inspects a container' do
       expect(Excon).to receive(:get).
-                           with(excon_uri + 'v1.12/containers/12345/json',
+                           with(excon_uri + "v1.12" + "/containers/12345/json",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem').
                            and_return(double(body: json_string, status: 200))
@@ -220,7 +220,7 @@ describe Centurion::DockerViaApi do
 
     it 'removes a container' do
       expect(Excon).to receive(:delete).
-                           with(excon_uri + 'v1.12/containers/12345',
+                           with(excon_uri + "v1.12" + "/containers/12345",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem').
                            and_return(double(status: 204))
@@ -235,7 +235,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.12/containers/json',
+                       with(excon_uri + "v1.12" + "/containers/json",
                             client_cert: File.expand_path('~/.docker/cert.pem'),
                             client_key: File.expand_path('~/.docker/key.pem')).
                        and_return(double(body: json_string, status: 200))

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -13,14 +13,14 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.7/containers/json', {}).
+                       with(excon_uri + 'v1.12/containers/json', {}).
                        and_return(double(body: json_string, status: 200))
       expect(api.ps).to eq(json_value)
     end
 
     it 'lists all processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.7/containers/json?all=1', {}).
+                       with(excon_uri + 'v1.12/containers/json?all=1', {}).
                        and_return(double(body: json_string, status: 200))
       expect(api.ps(all: true)).to eq(json_value)
     end
@@ -29,7 +29,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.10" + "/containers/create",
+                           with(excon_uri + "v1.12" + "/containers/create",
                                 query: nil,
                                 body: configuration_as_json,
                                 headers: {'Content-Type' => 'application/json'}).
@@ -41,7 +41,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.10" + "/containers/create",
+                           with(excon_uri + "v1.12" + "/containers/create",
                                 query: { name: match(/^app1-[a-f0-9]+$/) },
                                 body: configuration_as_json,
                                 headers: {'Content-Type' => 'application/json'}).
@@ -53,7 +53,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.10" + "/containers/12345/start",
+                           with(excon_uri + "v1.12" + "/containers/12345/start",
                                 body: configuration_as_json,
                                 headers: {'Content-Type' => 'application/json'}).
                            and_return(double(body: json_string, status: 204))
@@ -62,49 +62,49 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.7/containers/12345/stop?t=300', {}).
+                       with(excon_uri + 'v1.12/containers/12345/stop?t=300', {}).
                        and_return(double(status: 204))
       api.stop_container('12345', 300)
     end
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.7/containers/12345/stop?t=30', {}).
+                       with(excon_uri + 'v1.12/containers/12345/stop?t=30', {}).
                        and_return(double(status: 204))
       api.stop_container('12345')
     end
 
     it 'restarts a container' do
       expect(Excon).to receive(:post).
-                          with(excon_uri + "v1.10" + "/containers/12345/restart?t=30", {}).
+                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=30", {}).
                           and_return(double(body: json_string, status: 204))
       api.restart_container('12345')
     end
 
     it 'restarts a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                          with(excon_uri + "v1.10" + "/containers/12345/restart?t=300", {}).
+                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=300", {}).
                           and_return(double(body: json_string, status: 204))
       api.restart_container('12345', 300)
     end
 
     it 'inspects a container' do
       expect(Excon).to receive(:get).
-                           with(excon_uri + 'v1.7/containers/12345/json', {}).
+                           with(excon_uri + 'v1.12/containers/12345/json', {}).
                            and_return(double(body: json_string, status: 200))
       expect(api.inspect_container('12345')).to eq(json_value)
     end
 
     it 'removes a container' do
       expect(Excon).to receive(:delete).
-                           with(excon_uri + 'v1.7/containers/12345', {}).
+                           with(excon_uri + 'v1.12/containers/12345', {}).
                            and_return(double(status: 204))
       expect(api.remove_container('12345')).to eq(true)
     end
 
     it 'inspects an image' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.7" + "/images/foo:bar/json",
+                       with(excon_uri + "v1.12" + "/images/foo:bar/json",
                             headers: {'Accept' => 'application/json'}).
                        and_return(double(body: json_string, status: 200))
       expect(api.inspect_image('foo', 'bar')).to eq(json_value)
@@ -120,7 +120,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.7/containers/json',
+                       with(excon_uri + 'v1.12/containers/json',
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(body: json_string, status: 200))
@@ -129,7 +129,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists all processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.7/containers/json?all=1',
+                       with(excon_uri + 'v1.12/containers/json?all=1',
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(body: json_string, status: 200))
@@ -138,7 +138,7 @@ describe Centurion::DockerViaApi do
 
     it 'inspects an image' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.7/images/foo:bar/json',
+                       with(excon_uri + 'v1.12/images/foo:bar/json',
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem',
                             headers: {'Accept' => 'application/json'}).
@@ -150,7 +150,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + 'v1.10/containers/create',
+                           with(excon_uri + 'v1.12/containers/create',
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem',
                                 query: nil,
@@ -164,7 +164,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + 'v1.10/containers/12345/start',
+                           with(excon_uri + 'v1.12/containers/12345/start',
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem',
                                 body: configuration_as_json,
@@ -175,7 +175,7 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.7/containers/12345/stop?t=300',
+                       with(excon_uri + 'v1.12/containers/12345/stop?t=300',
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
@@ -184,7 +184,7 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + 'v1.7/containers/12345/stop?t=30',
+                       with(excon_uri + 'v1.12/containers/12345/stop?t=30',
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
@@ -193,7 +193,7 @@ describe Centurion::DockerViaApi do
 
     it 'restarts a container' do
       expect(Excon).to receive(:post).
-                        with(excon_uri + "v1.10" + "/containers/12345/restart?t=30",
+                        with(excon_uri + "v1.12" + "/containers/12345/restart?t=30",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                         and_return(double(body: json_string, status: 204))
@@ -202,7 +202,7 @@ describe Centurion::DockerViaApi do
 
     it 'restarts a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                        with(excon_uri + "v1.10" + "/containers/12345/restart?t=300",
+                        with(excon_uri + "v1.12" + "/containers/12345/restart?t=300",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                         and_return(double(body: json_string, status: 204))
@@ -211,7 +211,7 @@ describe Centurion::DockerViaApi do
 
     it 'inspects a container' do
       expect(Excon).to receive(:get).
-                           with(excon_uri + 'v1.7/containers/12345/json',
+                           with(excon_uri + 'v1.12/containers/12345/json',
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem').
                            and_return(double(body: json_string, status: 200))
@@ -220,7 +220,7 @@ describe Centurion::DockerViaApi do
 
     it 'removes a container' do
       expect(Excon).to receive(:delete).
-                           with(excon_uri + 'v1.7/containers/12345',
+                           with(excon_uri + 'v1.12/containers/12345',
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem').
                            and_return(double(status: 204))
@@ -235,7 +235,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + 'v1.7/containers/json',
+                       with(excon_uri + 'v1.12/containers/json',
                             client_cert: File.expand_path('~/.docker/cert.pem'),
                             client_key: File.expand_path('~/.docker/key.pem')).
                        and_return(double(body: json_string, status: 200))

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -4,6 +4,7 @@ require 'centurion/docker_via_api'
 describe Centurion::DockerViaApi do
   let(:hostname) { 'example.com' }
   let(:port) { '2375' }
+  let(:api_version) { '1.12' }
   let(:json_string) { '[{ "Hello": "World" }]' }
   let(:json_value) { JSON.load(json_string) }
 


### PR DESCRIPTION
Docker 1.8 only has backwards support back to version 1.12.   As a result having /v1.7 and /v1.10 hard coded into the docker_via_api breaks centurion for newer versions of docker.  I upgraded the Centurion::DockerViaApi class to take another optional parameters api_version.  As of right now all the only place that initializes the class will pass a nil value into it and it will get set to v1.12. In the future it would be easily possible to allow specifying the api version via the cli ( I will leave that for a future todo)

Docker 1.7 also supports api version 1.2, so this changes allows support for 1.7 in addition to 1.8. I noticed in some of the issues that new relic uses 1.5 (? not 100% about that), which also supports the v1.12.  As a result this change should not break backwards support.

This PR also fixes https://github.com/newrelic/centurion/issues/131