### PR TITLE
Don't override intentionally set project names.

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -55,7 +55,7 @@ invoke("environment:#{opts[:environment]}")
 set :image, opts[:image] if opts[:image]
 set :tag,   opts[:tag] if opts[:tag]
 set :hosts, opts[:hosts].split(",") if opts[:hosts]
-set :name,  opts[:project].gsub(/_/, '-')
+set :name,  opts[:project].gsub(/_/, '-') unless fetch(:name)
 
 # Override environment variables when specified
 if opts[:override_env]


### PR DESCRIPTION
This fix is grabbed from #128 thanks to @MarkBorcherding. It will change the behavior of Centurion to fix a bug, but may have the unintended consequence of changing the names of services that are currently running and have been getting the name of the file rather than the `:name` they tried to set. **I know that this might break some deployments at New Relic** and will need to be investigated before this can be merged. The effect would be duplicate services running in the worst case, one new version, one old. For services that bind to ports the risk of this is lower since they will collide. But it would need manual intervention to fix. We need to investigate all the service configs to see if this is an issue.

cc @benders @dselans 
