### PR TITLE
Don't healthcheck again on our way out of a successful healthcheck.

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -20,9 +20,11 @@ module Centurion::Deploy
 
   def wait_for_health_check_ok(health_check_method, target_server, container_id, port, endpoint, image_id, tag, sleep_time=5, retries=12)
     info 'Waiting for the port to come up'
+    healthy = false
     1.upto(retries) do
       if container_up?(target_server, container_id) && health_check_method.call(target_server, port, endpoint)
         info 'Container is up!'
+        healthy = true
         break
       end
 
@@ -30,7 +32,7 @@ module Centurion::Deploy
       sleep(sleep_time)
     end
 
-    unless health_check_method.call(target_server, port, endpoint)
+    unless healthy
       error "Failed to validate started container on #{target_server.hostname}:#{port}"
       exit(FAILED_CONTAINER_VALIDATION)
     end


### PR DESCRIPTION
During `deploy#wait_for_health_check_ok`, when the container is up and the health check passes, the fallthrough code attempts to detect the failed healthcheck case on its own, but if it had already passed, there's no need to re-healthcheck.

Services which pass their startup healthcheck but then move into an unhealthy state with the span of a method call would have their deploys aborted unnecessarily, also this just slows things down.