### PR TITLE
Add repair command to only deploy to unhealthy containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,14 @@ with `/bin/bash`. It will use the first host from the host list.
 ````bash
 $ bundle exec centurion -p radio-radio -e staging -a deploy_console
 ````
+### Repair unhealthy docker containers
+
+This will preform a health check on each host using rolling deployment
+health check settings and redeploy to the host if a health check fails.
+
+````bash
+$ bundle exec centurion -p radio-radio -e staging -a repair
+````
 
 ###List all the tags running on your servers for a particular project
 

--- a/lib/centurion/version.rb
+++ b/lib/centurion/version.rb
@@ -1,3 +1,3 @@
 module Centurion
-  VERSION = '1.8.3'
+  VERSION = '1.8.4'
 end


### PR DESCRIPTION
Added a new rake task that simply runs health checks on all servers and deploys to any that fail health checks.  This partially solves https://github.com/newrelic/centurion/issues/51 if run before running a rolling deployment.  I think that the functionality to repair is useful enough on its own that it should be able to be called directly.