### PR TITLE
Use ports first if they're mapped

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -7,8 +7,11 @@ module Centurion::Deploy
   FAILED_CONTAINER_VALIDATION = 100
 
   def stop_containers(target_server, service, timeout = 30)
-    old_containers = target_server.find_containers_by_name(service.name) || 
-                     target_server.find_containers_by_public_port(service.public_ports.first)
+    old_containers = if service.public_ports.nil? || service.public_ports.empty?
+      target_server.find_containers_by_name(service.name)
+    else
+      target_server.find_containers_by_public_port(service.public_ports.first)
+    end
 
     info "Stopping container(s): #{old_containers.inspect}"
 


### PR DESCRIPTION
Some people have done some crazy things with the internal API and are relying on differing ports and still using the same service name (bad idea). But we need to make that work without breaking backward compatibility so this is a solution that doesn't really compromise the code but allows that broken behavior to persist.

cc @dselans 