### PR TITLE
Made registry version and API version dynamic parameters

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -33,6 +33,8 @@ opts = Trollop::options do
   opt :registry_user,    'user for registry auth',               type: String, short: :none
   opt :registry_password,'password for registry auth',           type: String, short: :none
   opt :override_env,     'override environment variables, comma separated', type: String
+  opt :api_version,      'docker API version',                   type: String, short: :none
+  opt :registry_version, 'docker registry version',              type: String, short: '-r'
 end
 
 set_current_environment(opts[:environment].to_sym)
@@ -75,6 +77,8 @@ set :docker_path, opts[:docker_path]
 set :no_pull, opts[:no_pull_given]
 set :registry_user, opts[:registry_user] if opts[:registry_user]
 set :registry_password, opts[:registry_password] if opts[:registry_password]
+set :registry_version, opts[:registry_version] if opts[:registry_version]
+set :api_version, opts[:api_version] if opts[:api_version]
 
 invoke('centurion:setup')
 invoke(opts[:action])

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -133,8 +133,8 @@ module Centurion::DeployDSL
   private
 
   def build_server_group
-    hosts, docker_path = fetch(:hosts, []), fetch(:docker_path)
-    Centurion::DockerServerGroup.new(hosts, docker_path, build_tls_params)
+    hosts, docker_path, api_version = fetch(:hosts, []), fetch(:docker_path), fetch(:api_version)
+    Centurion::DockerServerGroup.new(hosts, docker_path, build_tls_params, api_version)
   end
 
   def validate_options_keys(options, valid_keys)

--- a/lib/centurion/docker_registry.rb
+++ b/lib/centurion/docker_registry.rb
@@ -1,20 +1,29 @@
 require 'excon'
 require 'json'
 require 'uri'
+require 'base64'
 
 module Centurion; end
 
 class Centurion::DockerRegistry
   OFFICIAL_URL = 'https://registry.hub.docker.com'
+  OFFICIAL_AUTH_URL = 'https://auth.docker.io/token'
 
-  def initialize(base_uri, registry_user=nil, registry_password=nil)
+  def initialize(base_uri, registry_user=nil, registry_password=nil, registry_version=nil)
     @base_uri = base_uri
     @user = registry_user
     @password = registry_password
+    registry_version ||= '1'
+    @registry_version = registry_version
   end
 
   def digest_for_tag(repository, tag)
-    path = "/v1/repositories/#{repository}/tags/#{tag}"
+    if @registry_version == '2'
+      digest_for_tag_v2(repository, path)
+    end
+
+    path = "/v#{@registry_version}/repositories/#{repository}/tags/#{tag}"
+
     uri = uri_for_repository_path(repository, path)
     $stderr.puts "GET: #{uri}"
     options = { headers: { "Content-Type" => "application/json" } }
@@ -35,7 +44,12 @@ class Centurion::DockerRegistry
   end
 
   def repository_tags(repository)
-    path = "/v1/repositories/#{repository}/tags"
+    if @registry_version == '2'
+      digest_for_tag_v2(repository, path)
+    end
+
+    path = "/v#{@registry_version}/repositories/#{repository}/tags"
+
     uri = uri_for_repository_path(repository, path)
 
     $stderr.puts "GET: #{uri.inspect}"
@@ -72,6 +86,70 @@ class Centurion::DockerRegistry
   end
 
   private
+
+  def v2_login(authentication)
+    auth_arr = authentication.split(' ')[1].split(',')
+    auth_hash = {}
+
+    auth_arr.each do |e|
+      key_value = e.split('=')
+      auth_hash[key_value[0]] = key_value[1].gsub!(/\A"|"\Z/, '')
+    end
+
+    path = "/?service=#{auth_hash['service']}&scope=#{auth_hash['scope']}"
+    uri = "#{auth_hash['realm'].gsub('token', 'v' + @registry_version) + '/token'}#{path}"
+
+    $stderr.puts "GET: #{uri.inspect}"
+
+    options = {
+      omit_default_port: true,
+      headers: { "Authorization" => "Basic #{Base64.strict_encode64(@user + ':' + @password)}" }
+    }
+
+    $stderr.puts "HEADERS: #{options.inspect}"
+
+    response = Excon.get(uri, options)
+
+    raise response.inspect unless response.status == 200
+
+    body = JSON.load(response.body)
+    raise "No token returned!" if body['token'].nil?
+
+    return body['token']
+  end
+
+  def digest_for_tag_v2(repository, tag)
+
+  end
+
+  def repository_tags_v2(repository, token = nil)
+    path = "/v#{@registry_version}/#{repository}/tags/list"
+    uri = uri_for_repository_path(repository, path)
+
+    $stderr.puts "GET: #{uri.inspect}"
+
+    # Need to workaround a bug in Docker Hub to now pass port in Host header
+    options = { omit_default_port: true }
+
+    unless token.nil?
+      options[:headers] = {
+        "Authorization" => "Bearer #{token}"
+      }
+    end
+
+    response = Excon.get(uri, options)
+
+    if response.status == 401
+      $stderr.puts "Authentication required! Getting token..."
+      token = v2_login(response.headers['Www-Authenticate'])
+      repository_tags_v2(repository, token)
+    elsif response.status == 200
+      body = JSON.load(response.body)
+      body['tags']
+    else
+      raise response.inspect
+    end
+  end
 
   def is_official_registry?(repository)
     return @base_uri == OFFICIAL_URL

--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -18,11 +18,13 @@ class Centurion::DockerServer
                  :remove_container, :restart_container
   def_delegators :docker_via_cli, :pull, :tail, :attach, :exec
 
-  def initialize(host, docker_path, tls_params = {})
+  def initialize(host, docker_path, tls_params = {}, api_version=nil)
     @docker_path = docker_path
     @hostname, @port = host.split(':')
     @port ||= '2375'
     @tls_params = tls_params
+    api_version ||= '1.12'
+    @api_version = api_version
   end
 
   def current_tags_for(image)
@@ -64,7 +66,7 @@ class Centurion::DockerServer
 
   def docker_via_api
     @docker_via_api ||= Centurion::DockerViaApi.new(@hostname, @port,
-                                                    @tls_params, nil)
+                                                    @tls_params, @api_version)
   end
 
   def docker_via_cli

--- a/lib/centurion/docker_server_group.rb
+++ b/lib/centurion/docker_server_group.rb
@@ -9,10 +9,11 @@ class Centurion::DockerServerGroup
 
   attr_reader :hosts
 
-  def initialize(hosts, docker_path, tls_params = {})
+  def initialize(hosts, docker_path, tls_params = {}, api_version=nil)
     raise ArgumentError.new('Bad Host list!') if hosts.nil? || hosts.empty?
+    api_version ||= '1.12'
     @hosts = hosts.map do |hostname|
-      Centurion::DockerServer.new(hostname, docker_path, tls_params)
+      Centurion::DockerServer.new(hostname, docker_path, tls_params, api_version)
     end
   end
 

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -9,13 +9,13 @@ class Centurion::DockerViaApi
   def initialize(hostname, port, tls_args = {}, api_version = nil)
     @tls_args = default_tls_args(tls_args[:tls]).merge(tls_args.reject { |k, v| v.nil? }) # Required by tls_enable?
     @base_uri = "http#{'s' if tls_enable?}://#{hostname}:#{port}"
-    api_version ||= "/v1.12"
+    api_version ||= "1.12"
     @docker_api_version = api_version
     configure_excon_globally
   end
 
   def ps(options={})
-    path = @docker_api_version + "/containers/json"
+    path = "/v#{@docker_api_version}/containers/json"
     path += "?all=1" if options[:all]
     response = Excon.get(@base_uri + path, tls_excon_arguments)
 
@@ -25,7 +25,7 @@ class Centurion::DockerViaApi
 
   def inspect_image(image, tag = "latest")
     repository = "#{image}:#{tag}"
-    path       = @docker_api_version + "/images/#{repository}/json"
+    path       = "/v#{@docker_api_version}/images/#{repository}/json"
 
     response = Excon.get(
       @base_uri + path,
@@ -36,7 +36,7 @@ class Centurion::DockerViaApi
   end
 
   def remove_container(container_id)
-    path = @docker_api_version + "/containers/#{container_id}"
+    path = "/v#{@docker_api_version}/containers/#{container_id}"
     response = Excon.delete(
       @base_uri + path,
       tls_excon_arguments
@@ -46,7 +46,7 @@ class Centurion::DockerViaApi
   end
 
   def stop_container(container_id, timeout = 30)
-    path = @docker_api_version + "/containers/#{container_id}/stop?t=#{timeout}"
+    path = "/v#{@docker_api_version}/containers/#{container_id}/stop?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -56,7 +56,7 @@ class Centurion::DockerViaApi
   end
 
   def create_container(configuration, name = nil)
-    path = @docker_api_version + "/containers/create"
+    path = "/v#{@docker_api_version}/containers/create"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -70,7 +70,7 @@ class Centurion::DockerViaApi
   end
 
   def start_container(container_id, configuration)
-    path = @docker_api_version + "/containers/#{container_id}/start"
+    path = "/v#{@docker_api_version}/containers/#{container_id}/start"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
@@ -89,7 +89,7 @@ class Centurion::DockerViaApi
   end
 
   def restart_container(container_id, timeout = 30)
-    path = @docker_api_version + "/containers/#{container_id}/restart?t=#{timeout}"
+    path = "/v#{@docker_api_version}/containers/#{container_id}/restart?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments
@@ -107,7 +107,7 @@ class Centurion::DockerViaApi
   end
 
   def inspect_container(container_id)
-    path = @docker_api_version + "/containers/#{container_id}/json"
+    path = "/v#{@docker_api_version}/containers/#{container_id}/json"
     response = Excon.get(
       @base_uri + path,
       tls_excon_arguments

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -148,7 +148,8 @@ namespace :deploy do
     registry = Centurion::DockerRegistry.new(
       fetch(:docker_registry),
       fetch(:registry_user),
-      fetch(:registry_password)
+      fetch(:registry_password),
+      fetch(:registry_version)
     )
     exact_image = registry.digest_for_tag(fetch(:image), fetch(:tag))
     set :image_id, exact_image

--- a/lib/tasks/list.rake
+++ b/lib/tasks/list.rake
@@ -27,11 +27,16 @@ namespace :list do
       registry = Centurion::DockerRegistry.new(
         fetch(:docker_registry),
         fetch(:registry_user),
-        fetch(:registry_password)
+        fetch(:registry_password),
+        fetch(:registry_version)
       )
       tags = registry.repository_tags(fetch(:image))
       tags.each do |tag|
-        puts "\t#{tag[0]}\t-> #{tag[1][0..11]}"
+        if tag.length > 1
+          puts "\t#{tag[0]}\t-> #{tag[1][0..11]}"
+        else
+          puts "\t#{tag[0]}"
+        end
       end
     rescue StandardError => e
       error "Couldn't communicate with Registry: #{e.message}"

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -10,18 +10,18 @@ describe Centurion::DockerViaApi do
 
   context 'without TLS certificates' do
     let(:excon_uri) { "http://#{hostname}:#{port}/" }
-    let(:api) { Centurion::DockerViaApi.new(hostname, port) }
+    let(:api) { Centurion::DockerViaApi.new(hostname, port, {}, api_version) }
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/containers/json", {}).
+                       with(excon_uri + "v#{api_version}/containers/json", {}).
                        and_return(double(body: json_string, status: 200))
       expect(api.ps).to eq(json_value)
     end
 
     it 'lists all processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/containers/json?all=1", {}).
+                       with(excon_uri + "v#{api_version}/containers/json?all=1", {}).
                        and_return(double(body: json_string, status: 200))
       expect(api.ps(all: true)).to eq(json_value)
     end
@@ -30,7 +30,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.12" + "/containers/create",
+                           with(excon_uri + "v#{api_version}/containers/create",
                                 query: nil,
                                 body: configuration_as_json,
                                 headers: {'Content-Type' => 'application/json'}).
@@ -42,7 +42,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.12" + "/containers/create",
+                           with(excon_uri + "v#{api_version}/containers/create",
                                 query: { name: match(/^app1-[a-f0-9]+$/) },
                                 body: configuration_as_json,
                                 headers: {'Content-Type' => 'application/json'}).
@@ -54,7 +54,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.12" + "/containers/12345/start",
+                           with(excon_uri + "v#{api_version}/containers/12345/start",
                                 body: configuration_as_json,
                                 headers: {'Content-Type' => 'application/json'}).
                            and_return(double(body: json_string, status: 204))
@@ -63,49 +63,49 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=300", {}).
+                       with(excon_uri + "v#{api_version}/containers/12345/stop?t=300", {}).
                        and_return(double(status: 204))
       api.stop_container('12345', 300)
     end
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=30", {}).
+                       with(excon_uri + "v#{api_version}/containers/12345/stop?t=30", {}).
                        and_return(double(status: 204))
       api.stop_container('12345')
     end
 
     it 'restarts a container' do
       expect(Excon).to receive(:post).
-                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=30", {}).
+                          with(excon_uri + "v#{api_version}/containers/12345/restart?t=30", {}).
                           and_return(double(body: json_string, status: 204))
       api.restart_container('12345')
     end
 
     it 'restarts a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=300", {}).
+                          with(excon_uri + "v#{api_version}/containers/12345/restart?t=300", {}).
                           and_return(double(body: json_string, status: 204))
       api.restart_container('12345', 300)
     end
 
     it 'inspects a container' do
       expect(Excon).to receive(:get).
-                           with(excon_uri + "v1.12" + "/containers/12345/json", {}).
+                           with(excon_uri + "v#{api_version}/containers/12345/json", {}).
                            and_return(double(body: json_string, status: 200))
       expect(api.inspect_container('12345')).to eq(json_value)
     end
 
     it 'removes a container' do
       expect(Excon).to receive(:delete).
-                           with(excon_uri + "v1.12" + "/containers/12345", {}).
+                           with(excon_uri + "v#{api_version}/containers/12345", {}).
                            and_return(double(status: 204))
       expect(api.remove_container('12345')).to eq(true)
     end
 
     it 'inspects an image' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/images/foo:bar/json",
+                       with(excon_uri + "v#{api_version}/images/foo:bar/json",
                             headers: {'Accept' => 'application/json'}).
                        and_return(double(body: json_string, status: 200))
       expect(api.inspect_image('foo', 'bar')).to eq(json_value)
@@ -121,7 +121,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/containers/json",
+                       with(excon_uri + "v#{api_version}/containers/json",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(body: json_string, status: 200))
@@ -130,7 +130,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists all processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/containers/json?all=1",
+                       with(excon_uri + "v#{api_version}/containers/json?all=1",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(body: json_string, status: 200))
@@ -139,7 +139,7 @@ describe Centurion::DockerViaApi do
 
     it 'inspects an image' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/images/foo:bar/json",
+                       with(excon_uri + "v#{api_version}/images/foo:bar/json",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem',
                             headers: {'Accept' => 'application/json'}).
@@ -151,7 +151,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.12" + "/containers/create",
+                           with(excon_uri + "v#{api_version}/containers/create",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem',
                                 query: nil,
@@ -165,7 +165,7 @@ describe Centurion::DockerViaApi do
       configuration_as_json = double
       configuration = double(to_json: configuration_as_json)
       expect(Excon).to receive(:post).
-                           with(excon_uri + "v1.12" + "/containers/12345/start",
+                           with(excon_uri + "v#{api_version}/containers/12345/start",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem',
                                 body: configuration_as_json,
@@ -176,7 +176,7 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=300",
+                       with(excon_uri + "v#{api_version}/containers/12345/stop?t=300",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
@@ -185,7 +185,7 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=30",
+                       with(excon_uri + "v#{api_version}/containers/12345/stop?t=30",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                        and_return(double(status: 204))
@@ -194,7 +194,7 @@ describe Centurion::DockerViaApi do
 
     it 'restarts a container' do
       expect(Excon).to receive(:post).
-                        with(excon_uri + "v1.12" + "/containers/12345/restart?t=30",
+                        with(excon_uri + "v#{api_version}/containers/12345/restart?t=30",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                         and_return(double(body: json_string, status: 204))
@@ -203,7 +203,7 @@ describe Centurion::DockerViaApi do
 
     it 'restarts a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                        with(excon_uri + "v1.12" + "/containers/12345/restart?t=300",
+                        with(excon_uri + "v#{api_version}/containers/12345/restart?t=300",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem').
                         and_return(double(body: json_string, status: 204))
@@ -212,7 +212,7 @@ describe Centurion::DockerViaApi do
 
     it 'inspects a container' do
       expect(Excon).to receive(:get).
-                           with(excon_uri + "v1.12" + "/containers/12345/json",
+                           with(excon_uri + "v#{api_version}/containers/12345/json",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem').
                            and_return(double(body: json_string, status: 200))
@@ -221,7 +221,7 @@ describe Centurion::DockerViaApi do
 
     it 'removes a container' do
       expect(Excon).to receive(:delete).
-                           with(excon_uri + "v1.12" + "/containers/12345",
+                           with(excon_uri + "v#{api_version}/containers/12345",
                                 client_cert: '/certs/cert.pem',
                                 client_key: '/certs/key.pem').
                            and_return(double(status: 204))
@@ -236,7 +236,7 @@ describe Centurion::DockerViaApi do
 
     it 'lists processes' do
       expect(Excon).to receive(:get).
-                       with(excon_uri + "v1.12" + "/containers/json",
+                       with(excon_uri + "v#{api_version}/containers/json",
                             client_cert: File.expand_path('~/.docker/cert.pem'),
                             client_key: File.expand_path('~/.docker/key.pem')).
                        and_return(double(body: json_string, status: 200))


### PR DESCRIPTION
This provides support for registry version 2 while maintaining backwards compatibility for version 1. I also built upon a previous set of commits making the API version dynamic by allowing it to be passed as a variable in the rake file or via a command line parameter.

Registry version can be set with

```
set :registry_version, '2'
```

API version can be set with

```
set :api_version, '1.20'
```
