### PR TITLE
Fix deploy_console and add new action to enter container using exec

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Your name could be here!
  * [Jon Wood][jellybob]
  * [Mark Borcherding][markborcherding]
  * [Nick Laferriere][laferrieren]
+ * [Hugo Chinchilla][hugochinchilla]
 
 Pre-release
 -----------

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -126,4 +126,14 @@ module Centurion::Deploy
 
     server.attach(container['Id'])
   end
+
+  def enter_container(server, service)
+    container = if service.public_ports.nil? || service.public_ports.empty?
+      server.find_containers_by_name(service.name).first
+    else
+      server.find_containers_by_public_port(service.public_ports.first).first
+    end
+
+    server.exec_it(container["Id"], "/bin/bash")
+  end
 end

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -8,6 +8,10 @@ module Centurion::DeployDSL
     build_server_group.tap { |hosts| hosts.each { |host| block.call(host) } }
   end
 
+  def on_first_docker_host(&block)
+    build_server_group.tap { |hosts| block.call(hosts.first) }
+  end
+
   def env_vars(new_vars)
     current = fetch(:env_vars, {})
     new_vars.each_pair do |new_key, new_value|

--- a/lib/centurion/docker_server.rb
+++ b/lib/centurion/docker_server.rb
@@ -16,7 +16,7 @@ class Centurion::DockerServer
   def_delegators :docker_via_api, :create_container, :inspect_container,
                  :inspect_image, :ps, :start_container, :stop_container,
                  :remove_container, :restart_container
-  def_delegators :docker_via_cli, :pull, :tail, :attach, :exec
+  def_delegators :docker_via_cli, :pull, :tail, :attach, :exec, :exec_it
 
   def initialize(host, docker_path, tls_params = {})
     @docker_path = docker_path

--- a/lib/centurion/docker_via_cli.rb
+++ b/lib/centurion/docker_via_cli.rb
@@ -31,6 +31,14 @@ class Centurion::DockerViaCli
     Centurion::Shell.echo(build_command(:exec, "#{container_id} #{commandline}"))
   end
 
+  def exec_it(container_id, commandline)
+    # the "or true" on the command is to prevent an exception from Shell.validate_status
+    # because docker exec returns the same exit code as the latest command executed on
+    # the shell, which causes an exception to be raised if the latest comand executed
+    # was unsuccessful when you exit the shell.
+    Centurion::Shell.echo(build_command(:exec, "-it #{container_id} #{commandline} || true"))
+  end
+
   private
 
   def self.tls_keys

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -24,6 +24,7 @@ task :rolling_deploy do
 end
 
 task :stop => ['deploy:stop']
+task :enter_container => ['deploy:enter_container']
 
 namespace :dev do
   task :export_only do
@@ -109,6 +110,12 @@ namespace :deploy do
     on_first_docker_host do |server|
       defined_service.port_bindings.clear
       launch_console(server, defined_service)
+    end
+  end
+
+  task :enter_container do
+    on_first_docker_host do |server|
+      enter_container(server, defined_service)
     end
   end
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -12,7 +12,7 @@ end
 
 task :deploy_console do
   invoke 'deploy:get_image'
-  invoke 'deploy:stop'
+  #invoke 'deploy:stop'
   invoke 'deploy:launch_console'
   invoke 'deploy:cleanup'
 end
@@ -106,7 +106,8 @@ namespace :deploy do
   end
 
   task :launch_console do
-    on_each_docker_host do |server|
+    on_first_docker_host do |server|
+      defined_service.port_bindings.clear
       launch_console(server, defined_service)
     end
   end


### PR DESCRIPTION
This fixes deploy_console, which currently stops the service on all hosts and then deploys the console in every host, disrupting the service availability.

The behavior of deploy_console has been changed so it creates an aditional container without port bindings to prevent port conflicts, it can be now used on single-host deploys without the service becoming unavailable.

Also I've added a new action which achieves the same result by using docker exec.

This should close #67 