### PR TITLE
fixed cgroup setting bug

### DIFF
--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -34,6 +34,8 @@ module Centurion
         s.port_bindings = fetch(:port_bindings, [])
         s.network_mode  = fetch(:network_mode, 'bridge')
         s.command       = fetch(:command, nil)
+        s.memory        = fetch(:memory, 0)
+        s.cpu_shares    = fetch(:cpu_shares, 0)
 
         s.add_env_vars(fetch(:env_vars, {}))
       end
@@ -140,6 +142,12 @@ module Centurion
 
       # Add ExtraHosts if needed
       host_config['ExtraHosts'] = extra_hosts if extra_hosts
+
+      # Set memory limits
+      host_config['Memory'] = memory if memory
+
+      # Set cpushare limits
+      host_config['CpuShares'] = cpu_shares if cpu_shares
 
       # Restart Policy
       if restart_policy

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -124,6 +124,16 @@ describe Centurion::DeployDSL do
       expect(DeployDSLTest.defined_service.network_mode).to eq('host')
     end
 
+    it 'accepts cpu share limit' do
+      DeployDSLTest.cpu_shares(12345678)
+      expect(DeployDSLTest.defined_service.cpu_shares).to eq(12345678)
+    end
+
+    it 'accepts memory limit' do
+      DeployDSLTest.memory(12345)
+      expect(DeployDSLTest.defined_service.memory).to eq(12345)
+    end
+
     it 'accepts bridge mode' do
       DeployDSLTest.network_mode('bridge')
       expect(DeployDSLTest.defined_service.network_mode).to eq('bridge')

--- a/spec/dogestry_spec.rb
+++ b/spec/dogestry_spec.rb
@@ -55,15 +55,6 @@ describe Centurion::Dogestry do
     end
   end
 
- describe '#pull' do
-   it 'returns correct value' do
-    if registry.which('dogestry')
-      expect(registry).to receive(:echo).with("dogestry #{flags} pull #{registry.s3_url} #{repo}")
-      registry.pull(repo, pull_hosts)
-    end
-   end
- end
-
   describe '#which' do
     it 'finds dogestry command line' do
       allow(File).to receive(:executable?).and_return(true)


### PR DESCRIPTION
Cgroup settings ceased to be set after the most recent refactor (and introduction of the Service class).
Was just a matter of the values not being fetched and set (in Service::self.from_env and Service::build_host_config)

Also added 2 new tests for mem/cpu share limits and removed a broken dogestry test.

@idleyoungman @intjonathan @relistan 