### PR TITLE
When parsing overridden env vars, only split on '=' once

### DIFF
--- a/bin/centurion
+++ b/bin/centurion
@@ -60,7 +60,7 @@ set :name,  opts[:project].gsub(/_/, '-')
 # Override environment variables when specified
 if opts[:override_env]
   opts[:override_env].split(',').each do |envvar|
-    key, value = envvar.split('=')
+    key, value = envvar.split('=', 2)
     env_vars(key => value)
   end
 end


### PR DESCRIPTION
This addresses the problem of passing in env vars with a literal `=` in them,
for instance `-XX:MaxGCPauseMillis=100`.

Previously, an invocation with:

    centurion --override-env JVM_OPTS=-XX:MaxGCPauseMillis=100

would cause the container to receive wrongly parsed data.

Unfortunatly, `bin/centurion` looks untested, so no tests :(

Fixes #158