### PR TITLE
Clarify the need for tlsverify=true even with custom cert paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,12 +292,15 @@ You have to set the following keys:
 
 ```ruby
   task :production => :common do
+    set :tlsverify, true
     set :tlscacert, '/usr/local/certs/ca.pem'
     set :tlscert, '/usr/local/certs/ssl.crt'
     set :tlskey, '/usr/local/certs/ssl.key'
     # ...
   end
 ```
+
+Mofidy the filenames as appropriate for your cert, ca, and key.
 
 Deploying
 ---------

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ You have to set the following keys:
   end
 ```
 
-Mofidy the filenames as appropriate for your cert, ca, and key.
+Modify the paths as appropriate for your cert, ca, and key files.
 
 Deploying
 ---------


### PR DESCRIPTION
Got caught up in this today, the docs make it look like you don't need `tlsverify: true` if you have custom cert paths. But you do.