### PR TITLE
Support non-integer values for cpu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+before_install:
+  - gem update bundler

--- a/lib/centurion/mesos_service.rb
+++ b/lib/centurion/mesos_service.rb
@@ -19,7 +19,7 @@ module Centurion
       @port_bindings = []
       @cap_adds      = []
       @cap_drops     = []
-      @network_mode  = ''
+      @network_mode  = 'bridge'
       Marathon.url   = marathon_url
     end
 
@@ -63,6 +63,15 @@ module Centurion
 
     def add_volume(host_volume, container_volume)
       @volumes << Volume.new(host_volume, container_volume)
+    end
+
+    def cpu_shares=(shares)
+      begin
+        Float(shares) != nil
+      rescue
+        raise ArgumentError, "invalid value for cgroup CPU constraint: #{shares}, value must be a between 0 and 18446744073709551615"
+      end
+      @cpu_shares = shares
     end
 
     def with_timeout timeout, &block

--- a/lib/centurion/mesos_service.rb
+++ b/lib/centurion/mesos_service.rb
@@ -9,8 +9,8 @@ module Centurion
 
     attr_accessor :instances, :min_health_capacity, :max_health_capacity, :executor,
                   :health_check, :health_check_args, :haproxy_mode, :health_check_grace_period,
-                  :health_check_interval, :health_check_max_count
-    attr_reader :env_vars, :cpu_shares, :memory, :image
+                  :health_check_interval, :health_check_max_count, :cpu_shares
+    attr_reader :env_vars, :memory, :image
 
     def initialize(name, marathon_url)
       @name          = name

--- a/spec/mesos_service_spec.rb
+++ b/spec/mesos_service_spec.rb
@@ -47,6 +47,8 @@ describe Centurion::MesosService do
 
   it 'rejects non-numeric cpu shares' do
     expect(-> { service.cpu_shares = 'all' }).to raise_error ArgumentError
+    expect(-> { service.cpu_shares = '' }).to raise_error ArgumentError
+    expect { service.cpu_shares = '1.5' }.to_not raise_error
   end
 
   it 'has a custom dns association' do


### PR DESCRIPTION
Moving cpu_shares from attr_reader to attr_accessor means that the cpu_shares=
method in lib/centurion/service.rb is not called and instead the cpu_shares
value is set directly.

MES-102

@actaeon Please review!