### PR TITLE
Add ipc_mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: ruby
+before_install:
+  - gem update
+  - gem install bundler

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -54,6 +54,10 @@ module Centurion::DeployDSL
     set(:command, command)
   end
 
+  def ipc_mode(mode)
+    set(:ipc_mode, mode)
+  end
+
   def localhost
     # DOCKER_HOST is like 'tcp://127.0.0.1:2375'
     docker_host_uri = URI.parse(ENV['DOCKER_HOST'] || "tcp://127.0.0.1")

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -5,7 +5,7 @@ module Centurion
   class Service
     extend ::Capistrano::DSL
 
-    attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops
+    attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops, :ipc_mode
     attr_reader :memory, :cpu_shares, :env_vars
 
     def initialize(name)
@@ -88,6 +88,10 @@ module Centurion
 
     def image=(image)
       @image = image
+    end
+
+    def ipc_mode=(mode)
+      @ipc_mode = mode
     end
 
     def build_config(server_hostname, &block)

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -5,7 +5,7 @@ module Centurion
   class Service
     extend ::Capistrano::DSL
 
-    attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops 
+    attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops
     attr_reader :memory, :cpu_shares, :env_vars
 
     def initialize(name)
@@ -36,6 +36,7 @@ module Centurion
         s.command       = fetch(:command, nil)
         s.memory        = fetch(:memory, 0)
         s.cpu_shares    = fetch(:cpu_shares, 0)
+        s.ipc_mode      = fetch(:ipc_mode, nil)
 
         s.add_env_vars(fetch(:env_vars, {}))
       end
@@ -148,6 +149,9 @@ module Centurion
 
       # Set cpushare limits
       host_config['CpuShares'] = cpu_shares if cpu_shares
+
+      # Set ipc mode
+      host_config['IpcMode'] = ipc_mode if ipc_mode
 
       # Restart Policy
       if restart_policy

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -46,7 +46,7 @@ describe Centurion::DeployDSL do
       expect(DeployDSLTest.defined_service.cap_adds).to eq(['IPC_LOCK'])
     end
 
-    it 'adds multiple capabilites' do 
+    it 'adds multiple capabilites' do
       DeployDSLTest.add_capability 'IPC_LOCK'
       DeployDSLTest.add_capability 'SYS_RESOURCE'
       expect(DeployDSLTest.defined_service.cap_adds).to eq(['IPC_LOCK', 'SYS_RESOURCE'])
@@ -63,12 +63,12 @@ describe Centurion::DeployDSL do
       expect(DeployDSLTest.defined_service.cap_drops).to eq(['IPC_LOCK'])
     end
 
-    it 'drops multiple capabilites' do 
+    it 'drops multiple capabilites' do
       DeployDSLTest.drop_capability 'IPC_LOCK'
       DeployDSLTest.drop_capability 'SYS_RESOURCE'
       expect(DeployDSLTest.defined_service.cap_drops).to eq(['IPC_LOCK', 'SYS_RESOURCE'])
     end
-  end      
+  end
 
   it 'adds hosts to the host list' do
     DeployDSLTest.set(:hosts, [ 'host1' ])
@@ -146,6 +146,13 @@ describe Centurion::DeployDSL do
 
     it 'fails when invalid mode is passed' do
       expect { DeployDSLTest.network_mode('foo') }.to raise_error(SystemExit)
+    end
+  end
+
+  describe '#ipc_mode' do
+    it 'accepts ipc host mode' do
+      DeployDSLTest.ipc_mode('host')
+      expect(DeployDSLTest.defined_service.ipc_mode).to eq('host')
     end
   end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -45,6 +45,11 @@ describe Centurion::Service do
     expect(service.cpu_shares).to eq(512)
   end
 
+  it 'has an ipc mode' do
+    service.ipc_mode = 'host'
+    expect(service.ipc_mode).to eq('host')
+  end
+
   it 'rejects non-numeric cpu shares' do
     expect(-> { service.cpu_shares = 'all' }).to raise_error
   end


### PR DESCRIPTION
Adds support for passing in ipc_mode to a docker container at run time:
https://docs.docker.com/engine/reference/run/#ipc-settings-ipc

This allows you to use the IPC namespace from the host rather than creating a new IPC namespace per container.

Sidekick @dselans ?