### PR TITLE
Support labels for containers

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -20,6 +20,14 @@ module Centurion::DeployDSL
     set(:env_vars, current)
   end
 
+  def labels(new_labels)
+    current = fetch(:labels, {})
+    new_labels.each_pair do |new_key, new_value|
+      current[new_key.to_s] = new_value.to_s
+    end
+    set(:labels, current)
+  end
+
   def add_capability(new_cap_adds)
     if !valid_capability?(new_cap_adds)
       abort("Invalid capability addition #{new_cap_adds} specified.")

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -6,7 +6,7 @@ module Centurion
     extend ::Capistrano::DSL
 
     attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops, :ipc_mode
-    attr_reader :memory, :cpu_shares, :env_vars
+    attr_reader :memory, :cpu_shares, :env_vars, :labels
 
     def initialize(name)
       @name          = name
@@ -15,6 +15,7 @@ module Centurion
       @port_bindings = []
       @cap_adds      = []
       @cap_drops     = []
+      @labels        = {}
       @network_mode  = 'bridge'
     end
 
@@ -38,6 +39,7 @@ module Centurion
         s.cpu_shares    = fetch(:cpu_shares, 0)
         s.ipc_mode      = fetch(:ipc_mode, nil)
 
+        s.add_labels(fetch(:labels, {}))
         s.add_env_vars(fetch(:env_vars, {}))
       end
     end
@@ -52,6 +54,10 @@ module Centurion
 
     def add_volume(host_volume, container_volume)
       @volumes << Volume.new(host_volume, container_volume)
+    end
+
+    def add_labels(labels)
+      @labels.merge!(Hash[labels.map { |(k,v)| [ k.to_s, v.to_s ]}])
     end
 
     def cap_adds=(capabilites)
@@ -101,6 +107,7 @@ module Centurion
         c['Cmd'] = command if command
         c['Memory'] = memory if memory
         c['CpuShares'] = cpu_shares if cpu_shares
+        c['Labels'] = labels unless labels.nil? || labels.empty?
       end
 
       unless port_bindings.empty?

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -40,6 +40,18 @@ describe Centurion::DeployDSL do
     )
   end
 
+  it 'adds new labels to the existing ones, as strings' do
+    DeployDSLTest.labels(Shakespeare: 'Hamlet')
+    DeployDSLTest.labels(Dickens: 'David Copperfield',
+                           Dickens_birth_year: 1812)
+
+    expect(DeployDSLTest.defined_service.labels).to eq(
+      'Shakespeare'        => 'Hamlet',
+      'Dickens'            => 'David Copperfield',
+      'Dickens_birth_year' => '1812'
+    )
+  end
+
   describe '#add_capability' do
     it 'adds one capability' do
       DeployDSLTest.add_capability 'IPC_LOCK'

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -6,6 +6,7 @@ describe Centurion::Service do
   let(:service)  { Centurion::Service.new(:redis) }
   let(:hostname) { 'shakespeare' }
   let(:image)    { 'redis' }
+  let(:labels)   { { 'test' => '123' } }
 
   it 'creates a service from the environment' do
     extend Capistrano::DSL
@@ -15,6 +16,7 @@ describe Centurion::Service do
     set(:hostname, hostname)
     set(:binds, [ Centurion::Service::Volume.new('/foo', '/foo/bar') ])
     set(:port_bindings, [ Centurion::Service::PortBinding.new(12340, 80, 'tcp') ])
+    set(:labels, labels)
 
     svc = Centurion::Service.from_env
     expect(svc.name).to eq('mycontainer')
@@ -24,6 +26,7 @@ describe Centurion::Service do
     expect(svc.volumes.first.host_volume).to eq('/foo')
     expect(svc.port_bindings.size).to eq(1)
     expect(svc.port_bindings.first.container_port).to eq(80)
+    expect(svc.labels).to eq(labels)
   end
 
   it 'starts with a command' do
@@ -68,6 +71,12 @@ describe Centurion::Service do
     service.add_env_vars(SLAVE_OF: '127.0.0.1')
     service.add_env_vars(USE_AOF: '1')
     expect(service.env_vars).to eq(SLAVE_OF: '127.0.0.1', USE_AOF: '1')
+  end
+
+  it 'has labels and flattens them all to text' do
+    service.add_labels(labels)
+    service.add_labels(another: 'label')
+    expect(service.labels).to eq(labels.merge('another' => 'label'))
   end
 
   it 'has volume bindings' do


### PR DESCRIPTION
This PR adds basic support (without interpolation) for labels at deployment time. These are useful in pretty much all modern Docker deployments.

cc @dselans
