### PR TITLE
Pass stop_timeout down to underlying http request

### DIFF
--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -49,7 +49,9 @@ class Centurion::DockerViaApi
     path = @docker_api_version + "/containers/#{container_id}/stop?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
-      tls_excon_arguments
+      tls_excon_arguments.merge(
+        read_timeout: timeout
+      )
     )
     raise response.inspect unless response.status == 204
     true


### PR DESCRIPTION
When setting a custom stop_timeout, the value is passed to the docker API, but Excon won't wait any longer than 120 seconds for the response. This can lead to incorrect timeout errors if the container takes longer than that to stop.

This passes the docker stop_timeout to the Excon request so it will wait at least as long as docker will for the container to stop.