### PR TITLE
avoid duplicate require due to symlinks

### DIFF
--- a/lib/centurion.rb
+++ b/lib/centurion.rb
@@ -1,9 +1,9 @@
 Dir[File.join(File.dirname(__FILE__), 'core_ext', '*')].each do |file|
-  require file
+  require File.realpath(file)
 end
 
 Dir[File.join(File.dirname(__FILE__), 'centurion', '*')].each do |file|
-  require file
+  require File.realpath(file)
 end
 
 module Centurion; end


### PR DESCRIPTION
When the centurion gem is installed under a symlinked directory, a simple `require 'centurion'` will error due to some files being loaded twice. Centurion requires some of its own files twice, once via `require <path>` and once again via `require_relative`.

In non-symlinked directories, Ruby will de-duplicate these duplicate requires automatically and the files will only get loaded once.
In the symlinked case, Ruby's de-duplication won't work because files loaded via `require_relative` are tracked by their canonical path, while files loaded via `require` are tracked by their requested path (which includes the symlink name).

This fix ensures that the files loaded via `require` will be requested using their canonical path, which should be identical to the path Ruby uses for files loaded via `require_relative`.