### PR TITLE
Parallelize docker stop for non-rolling deploys

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -98,9 +98,11 @@ namespace :deploy do
   # - remote: list
   # - remote: stop
   task :stop do
-    on_each_docker_host do |server|
-      stop_containers(server, defined_service, fetch(:stop_timeout, 30))
+    threads = on_each_docker_host.map do |server|
+      Thread.new { stop_containers(server, defined_service, fetch(:stop_timeout, 30)) }
     end
+
+    threads.each { |t| t.join }
   end
 
   # start


### PR DESCRIPTION
Waiting for a bunch of hosts to stop one at a time means that non-rolling deploys take a lot longer than they should, and it results in several hosts being offline for a very long time while waiting for the rest to stop.

Assuming Ruby works the way I think it does (which is about a 50/50 chance), this change should cause each of the hosts to do their docker stops in parallel and drastically reduce the wait time.