### PR TITLE
Wait longer for docker to kill containers during stop/restart

### DIFF
--- a/centurion.gemspec
+++ b/centurion.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'logger-colors'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'simplecov'

--- a/lib/centurion/docker_via_api.rb
+++ b/lib/centurion/docker_via_api.rb
@@ -50,7 +50,9 @@ class Centurion::DockerViaApi
     response = Excon.post(
       @base_uri + path,
       tls_excon_arguments.merge(
-        read_timeout: timeout
+        # Wait for both the docker stop timeout AND the kill AND
+        # potentially a very slow HTTP server.
+        read_timeout: timeout + 120
       )
     )
     raise response.inspect unless response.status == 204
@@ -94,7 +96,11 @@ class Centurion::DockerViaApi
     path = @docker_api_version + "/containers/#{container_id}/restart?t=#{timeout}"
     response = Excon.post(
       @base_uri + path,
-      tls_excon_arguments
+      tls_excon_arguments.merge(
+        # Wait for both the docker stop timeout AND the kill AND
+        # potentially a very slow HTTP server.
+        read_timeout: timeout + 120
+      )
     )
     case response.status
     when 204

--- a/lib/centurion/version.rb
+++ b/lib/centurion/version.rb
@@ -1,3 +1,3 @@
 module Centurion
-  VERSION = '1.8.9'
+  VERSION = '1.8.8'
 end

--- a/lib/centurion/version.rb
+++ b/lib/centurion/version.rb
@@ -1,3 +1,3 @@
 module Centurion
-  VERSION = '1.8.7'
+  VERSION = '1.8.9'
 end

--- a/spec/docker_via_api_spec.rb
+++ b/spec/docker_via_api_spec.rb
@@ -63,28 +63,29 @@ describe Centurion::DockerViaApi do
 
     it 'stops a container' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=300", {read_timeout: 300}).
+                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=300", {read_timeout: 420}).
                        and_return(double(status: 204))
       api.stop_container('12345', 300)
     end
 
     it 'stops a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=30", {read_timeout: 30}).
+                       with(excon_uri + "v1.12" + "/containers/12345/stop?t=30", {read_timeout: 150}).
                        and_return(double(status: 204))
       api.stop_container('12345')
     end
 
     it 'restarts a container' do
       expect(Excon).to receive(:post).
-                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=30", {}).
+                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=30", 
+                            {read_timeout: 150}).
                           and_return(double(body: json_string, status: 204))
       api.restart_container('12345')
     end
 
     it 'restarts a container with a custom timeout' do
       expect(Excon).to receive(:post).
-                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=300", {}).
+                          with(excon_uri + "v1.12" + "/containers/12345/restart?t=300", {:read_timeout=>420}).
                           and_return(double(body: json_string, status: 204))
       api.restart_container('12345', 300)
     end
@@ -179,7 +180,7 @@ describe Centurion::DockerViaApi do
                        with(excon_uri + "v1.12" + "/containers/12345/stop?t=300",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem',
-                            read_timeout: 300).
+                            read_timeout: 420).
                        and_return(double(status: 204))
       api.stop_container('12345', 300)
     end
@@ -189,7 +190,7 @@ describe Centurion::DockerViaApi do
                        with(excon_uri + "v1.12" + "/containers/12345/stop?t=30",
                             client_cert: '/certs/cert.pem',
                             client_key: '/certs/key.pem',
-                            read_timeout: 30).
+                            read_timeout: 150).
                        and_return(double(status: 204))
       api.stop_container('12345')
     end
@@ -198,7 +199,8 @@ describe Centurion::DockerViaApi do
       expect(Excon).to receive(:post).
                         with(excon_uri + "v1.12" + "/containers/12345/restart?t=30",
                             client_cert: '/certs/cert.pem',
-                            client_key: '/certs/key.pem').
+                            client_key: '/certs/key.pem',
+                            read_timeout: 150).
                         and_return(double(body: json_string, status: 204))
       api.restart_container('12345')
     end
@@ -207,7 +209,8 @@ describe Centurion::DockerViaApi do
       expect(Excon).to receive(:post).
                         with(excon_uri + "v1.12" + "/containers/12345/restart?t=300",
                             client_cert: '/certs/cert.pem',
-                            client_key: '/certs/key.pem').
+                            client_key: '/certs/key.pem',
+                            read_timeout: 420).
                         and_return(double(body: json_string, status: 204))
       api.restart_container('12345', 300)
     end


### PR DESCRIPTION
Passing identical timeouts to Docker and the Excon client resulted in
Excon giving up too soon when Docker was trying to kill timed-out containers.

For example, you may set a docker stop timeout of 30, expecting your
service to respond adequately to a KILL after 30 seconds. However,
your deploy would stop immediately after the 30 second timeout because
Excon would give up right away.

This adds 120 seconds to the given stop timeout, then passes that to
the Excon client. This should give the deploy plenty of time for
Docker to do its business even on sad servers.

Followup to #171