### PR TITLE
Search for host networking mode containers by name during stop_containers

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -7,7 +7,7 @@ module Centurion::Deploy
   FAILED_CONTAINER_VALIDATION = 100
 
   def stop_containers(target_server, service, timeout = 30)
-    old_containers = if service.public_ports.nil? || service.public_ports.empty?
+    old_containers = if service.public_ports.nil? || service.public_ports.empty? || service.network_mode == 'host'
       info "Looking for containers with names like #{service.name}"
       target_server.find_containers_by_name(service.name)
     else

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -147,6 +147,22 @@ describe Centurion::Deploy do
 
       test_deploy.stop_containers(server, service)
     end
+
+    it 'calls stop_container on the right containers in host networking mode' do
+      service = Centurion::Service.new(:centurion)
+      service.network_mode = 'host'
+      service.add_port_bindings(8080, 80)
+
+      second_container = container.dup
+      second_container = container.dup.tap { |c| c['Id'] = c['Id'].sub(/49494/, '55555') }
+      containers = [ container, second_container ]
+
+      expect(server).to receive(:find_containers_by_name).with(:centurion).and_return(containers)
+      expect(server).to receive(:stop_container).with(container['Id'], 30).once
+      expect(server).to receive(:stop_container).with(second_container['Id'], 30).once
+
+      test_deploy.stop_containers(server, service)
+    end
   end
 
   describe '#wait_for_load_balancer_check_interval' do


### PR DESCRIPTION
If a service uses host networking mode and you define a public port
for the purpose of healthchecking, the stop container call fails because
no such port is actually mapped.

This workaround allows you to define a "dummy" port that won't be mapped
(since host mode doesn't do that) but still satisfies the
wait_for_health_check_ok semantics by passing the port through.

It is a little weird that centurion "thinks" the port mappings exist
without docker actually creating them.

Resolves #164.