### PR TITLE
Add rolling_deploy_on_docker_failure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ are the same everywhere. Settings are per-project.
    ports are not HTTP services, this allows you to only health check the ports
    that are. The default is an empty array. If you have non-HTTP services that you
    want to check, see Custom Health Checks in the previous section.
- * `rolling_deploy_on_docker_failure` => What to do when Centurion encounters an error stopping or starting a container during a rolling deploy. By default, when an error is encountered the deploy will stop and immediately raise that error. If this option is set to `:continue` Centurion will continue deploying to the remaining hosts and raise at the end. 
+ * `rolling_deploy_on_failure` => What to do when Centurion encounters an error stopping or starting a container during a rolling deploy. By default, when an error is encountered the deploy will stop and immediately raise that error. If this option is set to `:continue` Centurion will continue deploying to the remaining hosts and raise at the end. 
 
 ###Deploy a project to a fleet of Docker servers
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ are the same everywhere. Settings are per-project.
    ports are not HTTP services, this allows you to only health check the ports
    that are. The default is an empty array. If you have non-HTTP services that you
    want to check, see Custom Health Checks in the previous section.
+ * `rolling_deploy_on_docker_failure` => What to do when Centurion encounters an error stopping or starting a container during a rolling deploy. By default, when an error is encountered the deploy will stop and immediately raise that error. If this option is set to `:continue` Centurion will continue deploying to the remaining hosts and raise at the end. 
 
 ###Deploy a project to a fleet of Docker servers
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -142,8 +142,8 @@ namespace :deploy do
         stop_containers(server, service, fetch(:stop_timeout, 30))
         container = start_new_container(server, service, defined_restart_policy)
       rescue e
-        on_fail = fetch(:rolling_deploy_on_docker_failure, :exit)
-        raise e unless on_fail == :continue
+        on_fail = fetch(:rolling_deploy_on_failure, :exit)
+        raise unless on_fail == :continue
         stop_start_errors << e.message
         next
       end


### PR DESCRIPTION
Currently, when a rolling deploy errors during the process of stopping an existing container and spinning up the new one, the deploy stops and exits by raising that error. The longer the list of servers you're deploying to, the more of a pain it is to determine which servers did and did not successfully deploy, and you're left in an inconsistent state.

This PR adds an option, `rolling_deploy_on_docker_failure` that defaults to `:exit`, which preserves the existing behavior. When set to `:continue`, Centurion will try to deploy to every host on its list and keep a running collection of the errors it encounters along the way. When all the servers are done, it will raise a single error with a concatenation of all the error messages it encountered. This should:

- Ensure hosts that are healthy at the time of deploy get deployed to, regardless of the health of other hosts in the list.
- Make it easier to see at the end of the deploy failure which hosts are unhealthy and still running the old container.