### PR TITLE
Remove Dogestry, fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Commercial Docker Registry Providers:
 Open-source:
 - The [Docker Distribution](https://github.com/docker/distribution) project,
   built and maintained by Docker. You host this yourself.
-- (*NEW!*) [Dogestry](https://github.com/dogestry/dogestry) is an
-  s3-backed Docker registry alternative that removes the requirement to set up
-  a centralized registry service or host anything yourself.
 
 Status
 ------
@@ -342,7 +339,7 @@ Deploying
 Centurion supports a number of tasks out of the box that make working with
 distributed containers easy.  Here are some examples:
 
-###Do a rolling deployment to a fleet of Docker servers
+### Do a rolling deployment to a fleet of Docker servers
 
 A rolling deployment will stop and start each container one at a time to make
 sure that the application stays available from the viewpoint of the load
@@ -412,7 +409,7 @@ are the same everywhere. Settings are per-project.
    that are. The default is an empty array. If you have non-HTTP services that you
    want to check, see Custom Health Checks in the previous section.
 
-###Deploy a project to a fleet of Docker servers
+### Deploy a project to a fleet of Docker servers
 
 This will hard stop, then start containers on all the specified hosts. This
 is not recommended for apps where one endpoint needs to be available at all
@@ -422,7 +419,7 @@ times. It is fast.
 $ bundle exec centurion -p radio-radio -e staging -a deploy
 ````
 
-###Deploy a bash console on a host
+### Deploy a bash console on a host
 
 This will give you a command line shell with all of your existing environment
 passed to the container. The `CMD` from the `Dockerfile` will be replaced
@@ -440,7 +437,7 @@ health check settings and redeploy to the host if a health check fails.
 $ bundle exec centurion -p radio-radio -e staging -a repair
 ````
 
-###List all the tags running on your servers for a particular project
+### List all the tags running on your servers for a particular project
 
 Returns a nicely-formatted list of all the current tags and which machines they
 are running on. Gives a unique list of tags across all hosts as well.  This is
@@ -451,7 +448,7 @@ goes wrong mid-deploy.
 $ bundle exec centurion -p radio-radio -e staging -a list:running_container_tags
 ```
 
-###List all the containers currently running for this project
+### List all the containers currently running for this project
 
 Returns a (as yet not very nicely formatted) list of all the containers for
 this project on each of the servers from the config.
@@ -460,7 +457,7 @@ this project on each of the servers from the config.
 $ bundle exec centurion -p radio-radio -e staging -a list:running_containers
 ```
 
-###List registry images
+### List registry images
 
 Returns a list of all the images for this project in the registry.
 


### PR DESCRIPTION
Dogestry stopped working with Docker 1.10 so we should stop advertising it, even though Centurion supports it. 

Secondly, now that GitHub Flavored Markdown has a grammar, you have to put spaces after ### at the beginning of lines

@intjonathan 