### PR TITLE
Support setting a seccomp profile in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,25 @@ drop_capability 'SOME_CAPABILITY'
 For more information on which kernel capabilities may be specified, see the
 [Docker docs](https://docs.docker.com/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration).
 
+### Setting the security options
+
+Some Docker platforms support container security overlays called `seccomp`. 
+During container creation, you may specify security options to control the 
+seccomp permissions. 
+
+To set a seccomp path:
+```ruby
+add_security_opt 'seccomp=/path/to/seccomp/profile.json'
+```
+
+Or, to unblock all syscalls in a container:
+
+```ruby
+add_security_opt 'seccomp=unconfined'
+```
+
+For more information on this argument, see the [Docker docs](https://docs.docker.com/engine/security/seccomp/).
+
 ### Interpolation
 
 Currently there a couple of special strings for interpolation that can be added

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -5,7 +5,7 @@ module Centurion
   class Service
     extend ::Capistrano::DSL
 
-    attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops, :ipc_mode
+    attr_accessor :command, :dns, :extra_hosts, :image, :name, :volumes, :port_bindings, :network_mode, :cap_adds, :cap_drops, :ipc_mode, :security_opt
     attr_reader :memory, :cpu_shares, :env_vars, :labels
 
     def initialize(name)
@@ -16,6 +16,7 @@ module Centurion
       @cap_adds      = []
       @cap_drops     = []
       @labels        = {}
+      @security_opt  = []
       @network_mode  = 'bridge'
     end
 
@@ -38,6 +39,7 @@ module Centurion
         s.memory        = fetch(:memory, 0)
         s.cpu_shares    = fetch(:cpu_shares, 0)
         s.ipc_mode      = fetch(:ipc_mode, nil)
+        s.security_opt  = fetch(:security_opt, [])
 
         s.add_labels(fetch(:labels, {}))
         s.add_env_vars(fetch(:env_vars, {}))
@@ -98,6 +100,10 @@ module Centurion
 
     def ipc_mode=(mode)
       @ipc_mode = mode
+    end
+
+    def add_security_opt(seccomp)
+      @security_opt << seccomp
     end
 
     def build_config(server_hostname, &block)
@@ -163,6 +169,9 @@ module Centurion
 
       # Set ipc mode
       host_config['IpcMode'] = ipc_mode if ipc_mode
+
+      # Set seccomp profile
+      host_config['SecurityOpt'] = security_opt unless security_opt.nil? || security_opt.empty?
 
       # Restart Policy
       if restart_policy

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -17,6 +17,7 @@ describe Centurion::Service do
     set(:binds, [ Centurion::Service::Volume.new('/foo', '/foo/bar') ])
     set(:port_bindings, [ Centurion::Service::PortBinding.new(12340, 80, 'tcp') ])
     set(:labels, labels)
+    set(:security_opt, ['seccomp=unconfined'])
 
     svc = Centurion::Service.from_env
     expect(svc.name).to eq('mycontainer')
@@ -27,6 +28,7 @@ describe Centurion::Service do
     expect(svc.port_bindings.size).to eq(1)
     expect(svc.port_bindings.first.container_port).to eq(80)
     expect(svc.labels).to eq(labels)
+    expect(svc.security_opt).to eq(['seccomp=unconfined'])
   end
 
   it 'starts with a command' do
@@ -171,6 +173,7 @@ describe Centurion::Service do
     service.cap_adds = ['IPC_BIND', 'NET_RAW']
     service.cap_drops = ['DAC_OVERRIDE']
     service.add_volume('/volumes/redis.8000', '/data')
+    service.security_opt = 'seccomp=unconfined'
 
     expect(service.build_host_config(Centurion::Service::RestartPolicy.new('on-failure', 10))).to eq({
       'Binds' => ['/volumes/redis.8000:/data'],
@@ -184,7 +187,8 @@ describe Centurion::Service do
       'RestartPolicy' => {
         'Name' => 'on-failure',
         'MaximumRetryCount' => 10
-      }
+      },
+      'SecurityOpt' => 'seccomp=unconfined'
     })
   end
 


### PR DESCRIPTION
If you want to do things like set a `numactl` option during container startup, Docker > 1.10 will stop you if you use the default seccomp profile.

This permits you to specify a path to another profile on the host, or set `unconfined` to permit all syscalls.