### PR TITLE
Assign lambdas to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Most of the DSL items (`host_port`, `host_volume`, `env_vars`, `host`) can be
 specified more than once and will append to the configuration. However, there
 can only be one `command`; the last one will take priority.
 
+You can also assign lambdas to environment variables. The lambda function will
+be invoked by Centurion with `server_hostname` as its only argument. This is
+useful to assign a sticky identity for each of the containers in the deploy.
+
 You can cause your container to be started with a specific DNS server
 IP address (the equivalent of `docker run --dns 172.17.42.1 ...`) like this:
 ```ruby

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -15,7 +15,7 @@ module Centurion::DeployDSL
   def env_vars(new_vars)
     current = fetch(:env_vars, {})
     new_vars.each_pair do |new_key, new_value|
-      current[new_key.to_s] = new_value.to_s
+      current[new_key.to_s] = new_value.respond_to?(:call) ? new_value : new_value.to_s
     end
     set(:env_vars, current)
   end

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -125,7 +125,6 @@ module Centurion
 
       unless env_vars.empty?
         container_config['Env'] = env_vars.map do |k,v|
-          puts "#{k} : #{v.class}"
           if v.respond_to? :call
             "#{k}=#{v.call(server_hostname)}"
           else

--- a/lib/centurion/service.rb
+++ b/lib/centurion/service.rb
@@ -125,7 +125,12 @@ module Centurion
 
       unless env_vars.empty?
         container_config['Env'] = env_vars.map do |k,v|
-          "#{k}=#{interpolate_var(v, server_hostname)}"
+          puts "#{k} : #{v.class}"
+          if v.respond_to? :call
+            "#{k}=#{v.call(server_hostname)}"
+          else
+            "#{k}=#{interpolate_var(v, server_hostname)}"
+          end
         end
       end
 

--- a/lib/centurion/version.rb
+++ b/lib/centurion/version.rb
@@ -1,3 +1,3 @@
 module Centurion
-  VERSION = '1.9.0'
+  VERSION = '1.9.2'
 end

--- a/spec/deploy_dsl_spec.rb
+++ b/spec/deploy_dsl_spec.rb
@@ -28,15 +28,18 @@ describe Centurion::DeployDSL do
     expect(DeployDSLTest.defined_service.command).to eq(command)
   end
 
-  it 'adds new env_vars to the existing ones, as strings' do
+  it 'adds new env_vars to the existing ones, maintaining lambdas' do
+    lambda = ->() { Random.rand(5) }
     DeployDSLTest.env_vars('SHAKESPEARE' => 'Hamlet')
     DeployDSLTest.env_vars('DICKENS' => 'David Copperfield',
-                           DICKENS_BIRTH_YEAR: 1812)
+                           DICKENS_BIRTH_YEAR: 1812,
+                           RANDOM_NUMBER: lambda)
 
     expect(DeployDSLTest.defined_service.env_vars).to eq(
       'SHAKESPEARE'        => 'Hamlet',
       'DICKENS'            => 'David Copperfield',
-      'DICKENS_BIRTH_YEAR' => '1812'
+      'DICKENS_BIRTH_YEAR' => '1812',
+      'RANDOM_NUMBER'      => lambda
     )
   end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -166,6 +166,12 @@ describe Centurion::Service do
     expect { service.add_env_vars(SOMETHING: true) }.not_to raise_error
   end
 
+  it 'does supports lambdas as env vars' do
+    service = Centurion::Service.new(:redis)
+    service.add_env_vars(DYNAMIC_VAR: ->(hostname) { "the-#{hostname}" })
+    expect(service.build_config('example.com')['Env']).to eq(['DYNAMIC_VAR=the-example.com'])
+  end
+
   it 'builds a valid docker host configuration' do
     service = Centurion::Service.new(:redis)
     service.dns = 'example.com'


### PR DESCRIPTION
```ruby
env_vars FOO: lambda { |hostname| "foo-#{hostname}" }
```

The lambda function will be invoked by Centurion with `server_hostname` as its only argument. This is useful to assign a sticky identity for each of the containers in the deploy.

**Usage example:** https://source.datanerd.us/site-engineering/centurion-configs/pull/4856/files