### PR TITLE
Reduce logging level for secrets 

### DIFF
--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -108,6 +108,7 @@ module Centurion::Deploy
 
     info "Starting new container #{container['Id'][0..7]}"
     server.start_container(container['Id'], host_config)
+    info "Container #{container['Id'][0..7]} successfully"
 
     # since this likely contains secrets we don't want to be always printing configurations
     debug "Inspecting new container #{container['Id'][0..7]}:"

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -109,9 +109,10 @@ module Centurion::Deploy
     info "Starting new container #{container['Id'][0..7]}"
     server.start_container(container['Id'], host_config)
 
-    info "Inspecting new container #{container['Id'][0..7]}:"
+    # since this likely contains secrets we don't want to be always printing configurations
+    debug "Inspecting new container #{container['Id'][0..7]}:"
     (server.inspect_container(container['Id']) || {}).each_pair do |key,value|
-      info "\t#{key} => #{value.inspect}"
+      debug "\t#{key} => #{value.inspect}"
     end
 
     container

--- a/lib/centurion/deploy.rb
+++ b/lib/centurion/deploy.rb
@@ -108,7 +108,7 @@ module Centurion::Deploy
 
     info "Starting new container #{container['Id'][0..7]}"
     server.start_container(container['Id'], host_config)
-    info "Container #{container['Id'][0..7]} successfully"
+    info "Started #{container['Id'][0..7]} successfully"
 
     # since this likely contains secrets we don't want to be always printing configurations
     debug "Inspecting new container #{container['Id'][0..7]}:"


### PR DESCRIPTION
Deployments will no longer show container configurations unless you set a lower logging level. This should hide secrets which are passed to containers at startup.

You can continue to view secrets for production deploys by turning up your log level.