### PR TITLE
Check permissions on remote Docker socket before forwarding it

### DIFF
--- a/lib/centurion/ssh.rb
+++ b/lib/centurion/ssh.rb
@@ -7,6 +7,8 @@ module Centurion; end
 module Centurion::SSH
   extend self
 
+  DOCKER_SOCKET_PATH = '/var/run/docker.sock'
+
   def with_docker_socket(hostname, user, log_level = nil)
     log_level ||= Logger::WARN
 
@@ -15,10 +17,16 @@ module Centurion::SSH
         ssh.logger = Logger.new STDERR
         ssh.logger.level = log_level
 
+        # Validate that we have access to the Docker socket before attempting to
+        # forward it. This ensures a meaningful error message if we don't.
+        if ssh.exec!("test -w '#{DOCKER_SOCKET_PATH}'").exitstatus != 0
+          raise "Docker socket at '#{DOCKER_SOCKET_PATH}' was not writable by user '#{user}' on '#{hostname}'. Is this user in the 'docker' group?"
+        end
+
         # Tempfile ensures permissions are 0600
         local_socket_path_file = Tempfile.new('docker_forward')
         local_socket_path = local_socket_path_file.path
-        ssh.forward.local_socket(local_socket_path, '/var/run/docker.sock')
+        ssh.forward.local_socket(local_socket_path, DOCKER_SOCKET_PATH)
 
         t = Thread.new do
           yield local_socket_path


### PR DESCRIPTION
Right now, if you try to run an SSH-based deploy with a user who doesn't actually have access to the Docker socket on the remote host, you get a rather un-helpful exception that looks like this:

```
Excon::Error::Socket: end of file reached (EOFError)
```

With this change, you'll get a somewhat more helpful error message that says:

```
RuntimeError: Docker socket at '/var/run/docker.sock' was not writable by user '<user>' on '<host>'. Is this user in the 'docker' group?
```