### PR TITLE
Fix Travis bundler errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 1.9.3-p551
   - 2.0.0
   - 2.1
   - 2.2
@@ -9,4 +9,7 @@ rvm:
   - 2.5
 before_install:
   - gem update
-  - gem install bundler
+  # downgrade bundler to fix installation error with ruby <= 2.2
+  # https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'


### PR DESCRIPTION
>On January 3rd 2019 the Bundler team released Bundler 2.0 which dropped support for Ruby versions 2.2 and older, and added a new dependency on RubyGems 3.0.0. A subsequent release, 2.0.1, requires RubyGems 2.5.0.

https://docs.travis-ci.com/user/languages/ruby/#bundler-20

This change downgrades bundler in order to allow installation of the project gems for build. Example of a successful build with this change [here](https://travis-ci.com/dstokes/centurion/jobs/217645900).

Additionally, I was seeing errors installing ruby-1.9.3 which is not listed in Travis' [list of precompiled ruby binaries](http://rubies.travis-ci.org/) so I updated that version to patch 551 (ruby-1.9.3-p551).